### PR TITLE
Fixed toString method of box filter

### DIFF
--- a/src/rfilters/box.cpp
+++ b/src/rfilters/box.cpp
@@ -48,7 +48,7 @@ public:
 	}
 
 	std::string toString() const {
-		return formatString("GaussianFilter[radius=%f]", m_radius);
+		return formatString("BoxFilter[radius=%f]", m_radius);
 	}
 
 	MTS_DECLARE_CLASS()


### PR DESCRIPTION
The toString method of the box reconstruction filter printed "GaussianFilter" instead of "BoxFilter".