### PR TITLE
Build error messages

### DIFF
--- a/build/SConscript.configure
+++ b/build/SConscript.configure
@@ -215,7 +215,7 @@ for ver in python_versions:
 	env['CPPPATH'][:] = [ x for x in env['CPPPATH'] if x not in includePath ]
 
 if not conf.CheckCXXHeader('boost/version.hpp'):
-	print 'Boost is missing (install libboost-all-dev)!'
+	print 'Boost is missing (install libboost-thread-dev, libboost-math-dev, libboost-system-dev, libboost-filesystem-dev)!'
 	Exit(1)
 if not conf.TryCompile("#include <boost/version.hpp>\n#if BOOST_VERSION < 104400\n#error Boost is outdated!\n#endif", ".cpp"):
 	print 'Boost is outdated (you will need version 1.44 or newer)!'

--- a/data/cmake/MitsubaExternal.cmake
+++ b/data/cmake/MitsubaExternal.cmake
@@ -75,7 +75,7 @@ if (NOT Boost_FOUND)
   set(BOOST_ROOT "" CACHE PATH
     "Preferred installation prefix for searching for Boost.")
   message(FATAL_ERROR
-    "Boost is missing. The required modules are math, filesystem and system.")
+    "Boost is missing. The required modules are thread, math, filesystem and system.")
 endif()
 mark_as_advanced(Boost_LIB_DIAGNOSTIC_DEFINITIONS)
 


### PR DESCRIPTION
Updated the build error messages concerning boost. In the current version, CMake does not list libboost-thread-dev as a required package.
In the SConscript configure file, it prompted the user to install libboost-dev-all on failure which seems like an overkill.