### PR TITLE
Work around hair shading frame computation

### DIFF
--- a/include/mitsuba/render/shape.h
+++ b/include/mitsuba/render/shape.h
@@ -278,6 +278,15 @@ public:
             const void *temp, Intersection &its) const;
 
     /**
+     * \brief Complete the given shading frame
+     *
+     * \remark This function should implicitly call
+     * \c computeShadingFrame, unless the shape
+     * needs a different initialization
+     */
+    virtual void fillShadingFrame(Intersection &its) const;
+
+    /**
      * \brief Return the derivative of the normal vector with
      * respect to the UV parameterization
      *
@@ -530,5 +539,3 @@ protected:
 MTS_NAMESPACE_END
 
 #endif /* __MITSUBA_RENDER_SHAPE_H_ */
-
-

--- a/include/mitsuba/render/skdtree.h
+++ b/include/mitsuba/render/skdtree.h
@@ -418,12 +418,13 @@ protected:
             its.primIndex = cache->primIndex;
             its.instance = NULL;
             its.time = ray.time;
+            its.shape->fillShadingFrame(its);
         } else {
             shape->fillIntersectionRecord(ray,
                 reinterpret_cast<const uint8_t*>(temp) + 2*sizeof(IndexType), its);
+            shape->fillShadingFrame(its);
         }
 
-        computeShadingFrame(its.shFrame.n, its.dpdu, its.shFrame);
         its.wi = its.toLocal(-ray.d);
     }
 

--- a/src/libcore/util.cpp
+++ b/src/libcore/util.cpp
@@ -601,6 +601,9 @@ void coordinateSystem(const Vector &a, Vector &b, Vector &c) {
 }
 
 void computeShadingFrame(const Vector &n, const Vector &dpdu, Frame &frame) {
+	const Vector fail(0, 0, 0);
+	SAssertEx(dpdu != fail, "Cannot compute a shading frame without dpdu!");
+
     frame.n = n;
     frame.s = normalize(dpdu - frame.n
         * dot(frame.n, dpdu));
@@ -608,6 +611,9 @@ void computeShadingFrame(const Vector &n, const Vector &dpdu, Frame &frame) {
 }
 
 void computeShadingFrameDerivative(const Vector &n, const Vector &dpdu, const Vector &dndu, const Vector &dndv, Frame &du, Frame &dv) {
+	const Vector fail(0, 0, 0);
+	SAssertEx(dpdu != fail, "Cannot compute a shading frame derivative without dpdu!");
+
     Vector s = dpdu - n * dot(n, dpdu);
     Float invLen_s = 1.0f / s.length();
     s *= invLen_s;

--- a/src/libcore/util.cpp
+++ b/src/libcore/util.cpp
@@ -601,8 +601,7 @@ void coordinateSystem(const Vector &a, Vector &b, Vector &c) {
 }
 
 void computeShadingFrame(const Vector &n, const Vector &dpdu, Frame &frame) {
-	const Vector fail(0, 0, 0);
-	SAssertEx(dpdu != fail, "Cannot compute a shading frame without dpdu!");
+    SAssertEx(!dpdu.isZero(), "Cannot compute a shading frame without dpdu!");
 
     frame.n = n;
     frame.s = normalize(dpdu - frame.n
@@ -611,8 +610,7 @@ void computeShadingFrame(const Vector &n, const Vector &dpdu, Frame &frame) {
 }
 
 void computeShadingFrameDerivative(const Vector &n, const Vector &dpdu, const Vector &dndu, const Vector &dndv, Frame &du, Frame &dv) {
-	const Vector fail(0, 0, 0);
-	SAssertEx(dpdu != fail, "Cannot compute a shading frame derivative without dpdu!");
+    SAssertEx(!dpdu.isZero(), "Cannot compute a shading frame derivative without dpdu!");
 
     Vector s = dpdu - n * dot(n, dpdu);
     Float invLen_s = 1.0f / s.length();

--- a/src/librender/shape.cpp
+++ b/src/librender/shape.cpp
@@ -205,6 +205,11 @@ void Shape::fillIntersectionRecord(const Ray &ray,
         const void *temp, Intersection &its) const {
     NotImplementedError("fillIntersectionRecord"); }
 
+void Shape::fillShadingFrame(Intersection &its) const
+{
+   computeShadingFrame(its.shFrame.n, its.dpdu, its.shFrame);
+}
+
 void Shape::getCurvature(const Intersection &its, Float &H, Float &K,
         bool shadingFrame) const {
     Vector dndu, dndv;

--- a/src/shapes/hair.cpp
+++ b/src/shapes/hair.cpp
@@ -851,6 +851,12 @@ void HairShape::fillIntersectionRecord(const Ray &ray,
     its.time = ray.time;
 }
 
+void HairShape::fillShadingFrame(Intersection & its) const
+{
+    // Since dpdu is NOT initialized, use the geometry frame instead
+    its.shFrame = its.geoFrame;
+}
+
 ref<TriMesh> HairShape::createTriMesh() {
     size_t nSegments = m_kdtree->getSegmentCount();
     /// Use very approximate geometry for large hair meshes

--- a/src/shapes/hair.h
+++ b/src/shapes/hair.h
@@ -71,6 +71,8 @@ public:
     void fillIntersectionRecord(const Ray &ray,
         const void *temp, Intersection &its) const;
 
+    void fillShadingFrame(Intersection &its) const;
+
     ref<TriMesh> createTriMesh();
 
     const KDTreeBase<AABB> *getKDTree() const;


### PR DESCRIPTION
Currently, the `Hair` shape does not initialize the partial derivatives `dpdu`, `dpdv` and the UV coordinates. Since ce80ddc, `computeShadingFrame` is used to set the shading frame for **all** Shapes; and because `dpdu` is not set, the shading frame's vectors are filled with 0 and NaNs.

This pull request fixes #25 by moving the `computeShadingFrame` call to the Shape itself via a wrapper `fillShadingFrame(Intersection)`, and then overriding it in `Hair` with `its.shFrame = its.geoFrame` from before ce80ddc.