### PR TITLE
Add Vertex Connection and Merging integrator

### DIFF
--- a/include/mitsuba/bidir/edge.h
+++ b/include/mitsuba/bidir/edge.h
@@ -408,7 +408,7 @@ struct MTS_EXPORT_BIDIR PathEdge {
      */
     bool pathConnectAndCollapse(const Scene *scene, const PathEdge *predEdge,
         const PathVertex *vs, const PathVertex *vt,
-        const PathEdge *succEdge, int &interactions);
+        const PathEdge *succEdge, int &interactions, bool ignore_visibility = false);
 
     /// Create a deep copy of this edge
     PathEdge *clone(MemoryPool &pool) const;

--- a/include/mitsuba/bidir/vertex.h
+++ b/include/mitsuba/bidir/vertex.h
@@ -142,6 +142,16 @@ struct MTS_EXPORT_BIDIR PathVertex {
     uint16_t componentType;
 
     /**
+    * \brief Marco: Stores the index of the component of the BRDF that was
+    * sampled. Note that this is different from what componentType stores;
+    * component Type stores the type of interaction while samplesBRDF Index
+    * stores the index of the sampled component of the intersected material.
+    *
+    * For materials with one component only it will be zero.
+    */
+    uint16_t sampledComponentIndex;
+
+    /**
      * \brief Measurement contribution weight
      *
      * This field stores the terms of the path-space measurement contribution
@@ -506,6 +516,9 @@ struct MTS_EXPORT_BIDIR PathVertex {
      */
     Float evalPdf(const Scene *scene, const PathVertex *pred,
         const PathVertex *succ, ETransportMode mode, EMeasure measure = EArea) const;
+
+    // evaluate the probability of selecting connectable components
+    Float evalSelectionProb(const Scene *scene, const PathVertex *pred, ETransportMode mode, Float th) const;
 
     /**
      * \brief Compute the area density of a provided emitter or sensor

--- a/include/mitsuba/core/nanoflann.h
+++ b/include/mitsuba/core/nanoflann.h
@@ -1,0 +1,1995 @@
+/***********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.
+ * Copyright 2008-2009  David G. Lowe (lowe@cs.ubc.ca). All rights reserved.
+ * Copyright 2011-2016  Jose Luis Blanco (joseluisblancoc@gmail.com).
+ *   All rights reserved.
+ *
+ * THE BSD LICENSE
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *************************************************************************/
+
+/** \mainpage nanoflann C++ API documentation
+  *  nanoflann is a C++ header-only library for building KD-Trees, mostly
+  *  optimized for 2D or 3D point clouds.
+  *
+  *  nanoflann does not require compiling or installing, just an
+  *  #include <nanoflann.hpp> in your code.
+  *
+  *  See:
+  *   - <a href="modules.html" >C++ API organized by modules</a>
+  *   - <a href="https://github.com/jlblancoc/nanoflann" >Online README</a>
+  *   - <a href="http://jlblancoc.github.io/nanoflann/" >Doxygen documentation</a>
+  */
+
+#ifndef  NANOFLANN_HPP_
+#define  NANOFLANN_HPP_
+
+#include <vector>
+#include <cassert>
+#include <algorithm>
+#include <stdexcept>
+#include <cstdio>  // for fwrite()
+#define _USE_MATH_DEFINES // Required by MSVC to define M_PI,etc. in <cmath>
+#include <cmath>   // for abs()
+#include <cstdlib> // for abs()
+#include <limits>
+
+// Avoid conflicting declaration of min/max macros in windows headers
+#if !defined(NOMINMAX) && (defined(_WIN32) || defined(_WIN32_)  || defined(WIN32) || defined(_WIN64))
+# define NOMINMAX
+# ifdef max
+#  undef   max
+#  undef   min
+# endif
+#endif
+
+namespace nanoflann
+{
+/** @addtogroup nanoflann_grp nanoflann C++ library for ANN
+  *  @{ */
+
+  	/** Library version: 0xMmP (M=Major,m=minor,P=patch) */
+	#define NANOFLANN_VERSION 0x123
+
+	/** @addtogroup result_sets_grp Result set classes
+	  *  @{ */
+	template <typename DistanceType, typename IndexType = size_t, typename CountType = size_t>
+	class KNNResultSet
+	{
+		IndexType * indices;
+		DistanceType* dists;
+		CountType capacity;
+		CountType count;
+
+	public:
+		inline KNNResultSet(CountType capacity_) : indices(0), dists(0), capacity(capacity_), count(0)
+		{
+		}
+
+		inline void init(IndexType* indices_, DistanceType* dists_)
+		{
+			indices = indices_;
+			dists = dists_;
+			count = 0;
+            if (capacity)
+                dists[capacity-1] = (std::numeric_limits<DistanceType>::max)();
+		}
+
+		inline CountType size() const
+		{
+			return count;
+		}
+
+		inline bool full() const
+		{
+			return count == capacity;
+		}
+
+
+                /**
+                 * Called during search to add an element matching the criteria.
+                 * @return true if the search should be continued, false if the results are sufficient
+                 */
+                inline bool addPoint(DistanceType dist, IndexType index)
+		{
+			CountType i;
+			for (i = count; i > 0; --i) {
+#ifdef NANOFLANN_FIRST_MATCH   // If defined and two points have the same distance, the one with the lowest-index will be returned first.
+				if ( (dists[i-1] > dist) || ((dist == dists[i-1]) && (indices[i-1] > index)) ) {
+#else
+				if (dists[i-1] > dist) {
+#endif
+					if (i < capacity) {
+						dists[i] = dists[i-1];
+						indices[i] = indices[i-1];
+					}
+				}
+				else break;
+			}
+			if (i < capacity) {
+				dists[i] = dist;
+				indices[i] = index;
+			}
+			if (count < capacity) count++;
+
+                        // tell caller that the search shall continue
+                        return true;
+		}
+
+		inline DistanceType worstDist() const
+		{
+			return dists[capacity-1];
+		}
+	};
+
+	/** operator "<" for std::sort() */
+	struct IndexDist_Sorter
+	{
+		/** PairType will be typically: std::pair<IndexType,DistanceType> */
+		template <typename PairType>
+		inline bool operator()(const PairType &p1, const PairType &p2) const {
+			return p1.second < p2.second;
+		}
+	};
+
+	/**
+	 * A result-set class used when performing a radius based search.
+	 */
+	template <typename DistanceType, typename IndexType = size_t>
+	class RadiusResultSet
+	{
+	public:
+		const DistanceType radius;
+
+		std::vector<std::pair<IndexType, DistanceType> > &m_indices_dists;
+
+		inline RadiusResultSet(DistanceType radius_, std::vector<std::pair<IndexType,DistanceType> > &indices_dists) : radius(radius_), m_indices_dists(indices_dists)
+		{
+			init();
+		}
+
+		inline void init() { clear(); }
+		inline void clear() { m_indices_dists.clear(); }
+
+		inline size_t size() const { return m_indices_dists.size(); }
+
+		inline bool full() const { return true; }
+
+                /**
+                 * Called during search to add an element matching the criteria.
+                 * @return true if the search should be continued, false if the results are sufficient
+                 */
+                inline bool addPoint(DistanceType dist, IndexType index)
+		{
+			if (dist < radius)
+				m_indices_dists.push_back(std::make_pair(index, dist));
+                        return true;
+		}
+
+		inline DistanceType worstDist() const { return radius; }
+
+		/**
+		 * Find the worst result (furtherest neighbor) without copying or sorting
+		 * Pre-conditions: size() > 0
+		 */
+		std::pair<IndexType,DistanceType> worst_item() const
+		{
+		   if (m_indices_dists.empty()) throw std::runtime_error("Cannot invoke RadiusResultSet::worst_item() on an empty list of results.");
+		   typedef typename std::vector<std::pair<IndexType, DistanceType> >::const_iterator DistIt;
+		   DistIt it = std::max_element(m_indices_dists.begin(), m_indices_dists.end(), IndexDist_Sorter());
+		   return *it;
+		}
+	};
+
+
+	/** @} */
+
+
+	/** @addtogroup loadsave_grp Load/save auxiliary functions
+	  * @{ */
+	template<typename T>
+	void save_value(FILE* stream, const T& value, size_t count = 1)
+	{
+		fwrite(&value, sizeof(value), count, stream);
+	}
+
+	template<typename T>
+	void save_value(FILE* stream, const std::vector<T>& value)
+	{
+		size_t size = value.size();
+		fwrite(&size, sizeof(size_t), 1, stream);
+		fwrite(&value[0], sizeof(T), size, stream);
+	}
+
+	template<typename T>
+	void load_value(FILE* stream, T& value, size_t count = 1)
+	{
+		size_t read_cnt = fread(&value, sizeof(value), count, stream);
+		if (read_cnt != count) {
+			throw std::runtime_error("Cannot read from file");
+		}
+	}
+
+
+	template<typename T>
+	void load_value(FILE* stream, std::vector<T>& value)
+	{
+		size_t size;
+		size_t read_cnt = fread(&size, sizeof(size_t), 1, stream);
+		if (read_cnt != 1) {
+			throw std::runtime_error("Cannot read from file");
+		}
+		value.resize(size);
+		read_cnt = fread(&value[0], sizeof(T), size, stream);
+		if (read_cnt != size) {
+			throw std::runtime_error("Cannot read from file");
+		}
+	}
+	/** @} */
+
+
+	/** @addtogroup metric_grp Metric (distance) classes
+	  * @{ */
+
+	struct Metric
+	{
+	};
+
+	/** Manhattan distance functor (generic version, optimized for high-dimensionality data sets).
+	  *  Corresponding distance traits: nanoflann::metric_L1
+	  * \tparam T Type of the elements (e.g. double, float, uint8_t)
+	  * \tparam _DistanceType Type of distance variables (must be signed) (e.g. float, double, int64_t)
+	  */
+	template<class T, class DataSource, typename _DistanceType = T>
+	struct L1_Adaptor
+	{
+		typedef T ElementType;
+		typedef _DistanceType DistanceType;
+
+		const DataSource &data_source;
+
+		L1_Adaptor(const DataSource &_data_source) : data_source(_data_source) { }
+
+		inline DistanceType evalMetric(const T* a, const size_t b_idx, size_t size, DistanceType worst_dist = -1) const
+		{
+			DistanceType result = DistanceType();
+			const T* last = a + size;
+			const T* lastgroup = last - 3;
+			size_t d = 0;
+
+			/* Process 4 items with each loop for efficiency. */
+			while (a < lastgroup) {
+				const DistanceType diff0 = std::abs(a[0] - data_source.kdtree_get_pt(b_idx,d++));
+				const DistanceType diff1 = std::abs(a[1] - data_source.kdtree_get_pt(b_idx,d++));
+				const DistanceType diff2 = std::abs(a[2] - data_source.kdtree_get_pt(b_idx,d++));
+				const DistanceType diff3 = std::abs(a[3] - data_source.kdtree_get_pt(b_idx,d++));
+				result += diff0 + diff1 + diff2 + diff3;
+				a += 4;
+				if ((worst_dist > 0) && (result > worst_dist)) {
+					return result;
+				}
+			}
+			/* Process last 0-3 components.  Not needed for standard vector lengths. */
+			while (a < last) {
+				result += std::abs( *a++ - data_source.kdtree_get_pt(b_idx, d++) );
+			}
+			return result;
+		}
+
+		template <typename U, typename V>
+		inline DistanceType accum_dist(const U a, const V b, int ) const
+		{
+			return std::abs(a-b);
+		}
+	};
+
+	/** Squared Euclidean distance functor (generic version, optimized for high-dimensionality data sets).
+	  *  Corresponding distance traits: nanoflann::metric_L2
+	  * \tparam T Type of the elements (e.g. double, float, uint8_t)
+	  * \tparam _DistanceType Type of distance variables (must be signed) (e.g. float, double, int64_t)
+	  */
+	template<class T, class DataSource, typename _DistanceType = T>
+	struct L2_Adaptor
+	{
+		typedef T ElementType;
+		typedef _DistanceType DistanceType;
+
+		const DataSource &data_source;
+
+		L2_Adaptor(const DataSource &_data_source) : data_source(_data_source) { }
+
+		inline DistanceType evalMetric(const T* a, const size_t b_idx, size_t size, DistanceType worst_dist = -1) const
+		{
+			DistanceType result = DistanceType();
+			const T* last = a + size;
+			const T* lastgroup = last - 3;
+			size_t d = 0;
+
+			/* Process 4 items with each loop for efficiency. */
+			while (a < lastgroup) {
+				const DistanceType diff0 = a[0] - data_source.kdtree_get_pt(b_idx,d++);
+				const DistanceType diff1 = a[1] - data_source.kdtree_get_pt(b_idx,d++);
+				const DistanceType diff2 = a[2] - data_source.kdtree_get_pt(b_idx,d++);
+				const DistanceType diff3 = a[3] - data_source.kdtree_get_pt(b_idx,d++);
+				result += diff0 * diff0 + diff1 * diff1 + diff2 * diff2 + diff3 * diff3;
+				a += 4;
+				if ((worst_dist > 0) && (result > worst_dist)) {
+					return result;
+				}
+			}
+			/* Process last 0-3 components.  Not needed for standard vector lengths. */
+			while (a < last) {
+				const DistanceType diff0 = *a++ - data_source.kdtree_get_pt(b_idx, d++);
+				result += diff0 * diff0;
+			}
+			return result;
+		}
+
+		template <typename U, typename V>
+		inline DistanceType accum_dist(const U a, const V b, int ) const
+		{
+			return (a - b) * (a - b);
+		}
+	};
+
+	/** Squared Euclidean (L2) distance functor (suitable for low-dimensionality datasets, like 2D or 3D point clouds)
+	  *  Corresponding distance traits: nanoflann::metric_L2_Simple
+	  * \tparam T Type of the elements (e.g. double, float, uint8_t)
+	  * \tparam _DistanceType Type of distance variables (must be signed) (e.g. float, double, int64_t)
+	  */
+	template<class T, class DataSource, typename _DistanceType = T>
+	struct L2_Simple_Adaptor
+	{
+		typedef T ElementType;
+		typedef _DistanceType DistanceType;
+
+		const DataSource &data_source;
+
+		L2_Simple_Adaptor(const DataSource &_data_source) : data_source(_data_source) { }
+
+		inline DistanceType evalMetric(const T* a, const size_t b_idx, size_t size) const {
+			DistanceType result = DistanceType();
+			for (size_t i = 0; i < size; ++i) {
+				const DistanceType diff = a[i] - data_source.kdtree_get_pt(b_idx, i);
+				result += diff * diff;
+			}
+			return result;
+		}
+
+		template <typename U, typename V>
+		inline DistanceType accum_dist(const U a, const V b, int ) const
+		{
+			return (a - b) * (a - b);
+		}
+	};
+
+	/** SO2 distance functor
+	  *  Corresponding distance traits: nanoflann::metric_SO2
+	  * \tparam T Type of the elements (e.g. double, float)
+	  * \tparam _DistanceType Type of distance variables (must be signed) (e.g. float, double)
+	  * orientation is constrained to be in [-pi, pi]
+	  */
+	template<class T, class DataSource, typename _DistanceType = T>
+	struct SO2_Adaptor
+	{
+		typedef T ElementType;
+		typedef _DistanceType DistanceType;
+
+		const DataSource &data_source;
+
+		SO2_Adaptor(const DataSource &_data_source) : data_source(_data_source) { }
+
+		inline DistanceType evalMetric(const T* a, const size_t b_idx, size_t size) const {
+			return accum_dist(a[size-1], data_source.kdtree_get_pt(b_idx, size - 1) , size - 1);
+		}
+
+		template <typename U, typename V>
+		inline DistanceType accum_dist(const U a, const V b, int ) const
+		{
+			DistanceType result = DistanceType();
+			result = b - a;
+			if (result > M_PI)
+				result -= 2. * M_PI;
+			else if (result < -M_PI)
+				result += 2. * M_PI;
+			return result;
+		}
+	};
+
+	/** SO3 distance functor (Uses L2_Simple)
+	  *  Corresponding distance traits: nanoflann::metric_SO3
+	  * \tparam T Type of the elements (e.g. double, float)
+	  * \tparam _DistanceType Type of distance variables (must be signed) (e.g. float, double)
+	  */
+	template<class T, class DataSource, typename _DistanceType = T>
+	struct SO3_Adaptor
+	{
+		typedef T ElementType;
+		typedef _DistanceType DistanceType;
+
+		L2_Simple_Adaptor<T, DataSource > distance_L2_Simple;
+
+		SO3_Adaptor(const DataSource &_data_source) : distance_L2_Simple(_data_source) { }
+
+		inline DistanceType evalMetric(const T* a, const size_t b_idx, size_t size) const {
+			return distance_L2_Simple.evalMetric(a, b_idx, size);
+		}
+
+		template <typename U, typename V>
+		inline DistanceType accum_dist(const U a, const V b, int idx) const
+		{
+			return distance_L2_Simple.accum_dist(a, b, idx);
+		}
+	};
+
+	/** Metaprogramming helper traits class for the L1 (Manhattan) metric */
+	struct metric_L1 : public Metric
+	{
+		template<class T, class DataSource>
+		struct traits {
+			typedef L1_Adaptor<T, DataSource> distance_t;
+		};
+	};
+	/** Metaprogramming helper traits class for the L2 (Euclidean) metric */
+	struct metric_L2 : public Metric 
+	{
+		template<class T, class DataSource>
+		struct traits {
+			typedef L2_Adaptor<T, DataSource> distance_t;
+		};
+	};
+	/** Metaprogramming helper traits class for the L2_simple (Euclidean) metric */
+	struct metric_L2_Simple : public Metric
+	{
+		template<class T, class DataSource>
+		struct traits {
+			typedef L2_Simple_Adaptor<T, DataSource> distance_t;
+		};
+	};
+	/** Metaprogramming helper traits class for the SO3_InnerProdQuat metric */
+	struct metric_SO2 : public Metric 
+	{
+		template<class T, class DataSource>
+		struct traits {
+			typedef SO2_Adaptor<T, DataSource> distance_t;
+		};
+	};
+	/** Metaprogramming helper traits class for the SO3_InnerProdQuat metric */
+	struct metric_SO3 : public Metric
+	{
+		template<class T, class DataSource>
+		struct traits {
+			typedef SO3_Adaptor<T, DataSource> distance_t;
+		};
+	};
+
+	/** @} */
+
+	/** @addtogroup param_grp Parameter structs
+	  * @{ */
+
+	/**  Parameters (see README.md) */
+	struct KDTreeSingleIndexAdaptorParams
+	{
+		KDTreeSingleIndexAdaptorParams(size_t _leaf_max_size = 10) :
+			leaf_max_size(_leaf_max_size)
+		{}
+
+		size_t leaf_max_size;
+	};
+
+	/** Search options for KDTreeSingleIndexAdaptor::findNeighbors() */
+	struct SearchParams
+	{
+		/** Note: The first argument (checks_IGNORED_) is ignored, but kept for compatibility with the FLANN interface */
+		SearchParams(int checks_IGNORED_ = 32, float eps_ = 0, bool sorted_ = true ) :
+			checks(checks_IGNORED_), eps(eps_), sorted(sorted_) {}
+
+		int   checks;  //!< Ignored parameter (Kept for compatibility with the FLANN interface).
+		float eps;  //!< search for eps-approximate neighbours (default: 0)
+		bool sorted; //!< only for radius search, require neighbours sorted by distance (default: true)
+	};
+	/** @} */
+
+
+	/** @addtogroup memalloc_grp Memory allocation
+	  * @{ */
+
+	/**
+	 * Allocates (using C's malloc) a generic type T.
+	 *
+	 * Params:
+	 *     count = number of instances to allocate.
+	 * Returns: pointer (of type T*) to memory buffer
+	 */
+	template <typename T>
+	inline T* allocate(size_t count = 1)
+	{
+		T* mem = static_cast<T*>( ::malloc(sizeof(T)*count));
+		return mem;
+	}
+
+
+	/**
+	 * Pooled storage allocator
+	 *
+	 * The following routines allow for the efficient allocation of storage in
+	 * small chunks from a specified pool.  Rather than allowing each structure
+	 * to be freed individually, an entire pool of storage is freed at once.
+	 * This method has two advantages over just using malloc() and free().  First,
+	 * it is far more efficient for allocating small objects, as there is
+	 * no overhead for remembering all the information needed to free each
+	 * object or consolidating fragmented memory.  Second, the decision about
+	 * how long to keep an object is made at the time of allocation, and there
+	 * is no need to track down all the objects to free them.
+	 *
+	 */
+
+	const size_t     WORDSIZE = 16;
+	const size_t     BLOCKSIZE = 8192;
+
+	class PooledAllocator
+	{
+		/* We maintain memory alignment to word boundaries by requiring that all
+		    allocations be in multiples of the machine wordsize.  */
+		/* Size of machine word in bytes.  Must be power of 2. */
+		/* Minimum number of bytes requested at a time from	the system.  Must be multiple of WORDSIZE. */
+
+
+		size_t  remaining;  /* Number of bytes left in current block of storage. */
+		void*   base;     /* Pointer to base of current block of storage. */
+		void*   loc;      /* Current location in block to next allocate memory. */
+
+		void internal_init()
+		{
+			remaining = 0;
+			base = NULL;
+			usedMemory = 0;
+			wastedMemory = 0;
+		}
+
+	public:
+		size_t  usedMemory;
+		size_t  wastedMemory;
+
+		/**
+		    Default constructor. Initializes a new pool.
+		 */
+		PooledAllocator() {
+			internal_init();
+		}
+
+		/**
+		 * Destructor. Frees all the memory allocated in this pool.
+		 */
+		~PooledAllocator() {
+			free_all();
+		}
+
+		/** Frees all allocated memory chunks */
+		void free_all()
+		{
+			while (base != NULL) {
+				void *prev = *(static_cast<void**>( base)); /* Get pointer to prev block. */
+				::free(base);
+				base = prev;
+			}
+			internal_init();
+		}
+
+		/**
+		 * Returns a pointer to a piece of new memory of the given size in bytes
+		 * allocated from the pool.
+		 */
+		void* malloc(const size_t req_size)
+		{
+			/* Round size up to a multiple of wordsize.  The following expression
+			    only works for WORDSIZE that is a power of 2, by masking last bits of
+			    incremented size to zero.
+			 */
+			const size_t size = (req_size + (WORDSIZE - 1)) & ~(WORDSIZE - 1);
+
+			/* Check whether a new block must be allocated.  Note that the first word
+			    of a block is reserved for a pointer to the previous block.
+			 */
+			if (size > remaining) {
+
+				wastedMemory += remaining;
+
+				/* Allocate new storage. */
+				const size_t blocksize = (size + sizeof(void*) + (WORDSIZE - 1) > BLOCKSIZE) ?
+							size + sizeof(void*) + (WORDSIZE - 1) : BLOCKSIZE;
+
+				// use the standard C malloc to allocate memory
+				void* m = ::malloc(blocksize);
+				if (!m) {
+					fprintf(stderr, "Failed to allocate memory.\n");
+					return NULL;
+				}
+
+				/* Fill first word of new block with pointer to previous block. */
+				static_cast<void**>(m)[0] = base;
+				base = m;
+
+				size_t shift = 0;
+				//int size_t = (WORDSIZE - ( (((size_t)m) + sizeof(void*)) & (WORDSIZE-1))) & (WORDSIZE-1);
+
+				remaining = blocksize - sizeof(void*) - shift;
+				loc = (static_cast<char*>(m) + sizeof(void*) + shift);
+			}
+			void* rloc = loc;
+			loc = static_cast<char*>(loc) + size;
+			remaining -= size;
+
+			usedMemory += size;
+
+			return rloc;
+		}
+
+		/**
+		 * Allocates (using this pool) a generic type T.
+		 *
+		 * Params:
+		 *     count = number of instances to allocate.
+		 * Returns: pointer (of type T*) to memory buffer
+		 */
+		template <typename T>
+		T* allocate(const size_t count = 1)
+		{
+			T* mem = static_cast<T*>(this->malloc(sizeof(T)*count));
+			return mem;
+		}
+
+	};
+	/** @} */
+
+	/** @addtogroup nanoflann_metaprog_grp Auxiliary metaprogramming stuff
+	  * @{ */
+
+	// ----------------  CArray -------------------------
+	/** A STL container (as wrapper) for arrays of constant size defined at compile time (class imported from the MRPT project)
+	 * This code is an adapted version from Boost, modifed for its integration
+	 *	within MRPT (JLBC, Dec/2009) (Renamed array -> CArray to avoid possible potential conflicts).
+	 * See
+	 *      http://www.josuttis.com/cppcode
+	 * for details and the latest version.
+	 * See
+	 *      http://www.boost.org/libs/array for Documentation.
+	 * for documentation.
+	 *
+	 * (C) Copyright Nicolai M. Josuttis 2001.
+	 * Permission to copy, use, modify, sell and distribute this software
+	 * is granted provided this copyright notice appears in all copies.
+	 * This software is provided "as is" without express or implied
+	 * warranty, and with no claim as to its suitability for any purpose.
+	 *
+	 * 29 Jan 2004 - minor fixes (Nico Josuttis)
+	 * 04 Dec 2003 - update to synch with library TR1 (Alisdair Meredith)
+	 * 23 Aug 2002 - fix for Non-MSVC compilers combined with MSVC libraries.
+	 * 05 Aug 2001 - minor update (Nico Josuttis)
+	 * 20 Jan 2001 - STLport fix (Beman Dawes)
+	 * 29 Sep 2000 - Initial Revision (Nico Josuttis)
+	 *
+	 * Jan 30, 2004
+	 */
+    template <typename T, std::size_t N>
+    class CArray {
+      public:
+        T elems[N];    // fixed-size array of elements of type T
+
+      public:
+        // type definitions
+        typedef T              value_type;
+        typedef T*             iterator;
+        typedef const T*       const_iterator;
+        typedef T&             reference;
+        typedef const T&       const_reference;
+        typedef std::size_t    size_type;
+        typedef std::ptrdiff_t difference_type;
+
+        // iterator support
+        inline iterator begin() { return elems; }
+        inline const_iterator begin() const { return elems; }
+        inline iterator end() { return elems+N; }
+        inline const_iterator end() const { return elems+N; }
+
+        // reverse iterator support
+#if !defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION) && !defined(BOOST_MSVC_STD_ITERATOR) && !defined(BOOST_NO_STD_ITERATOR_TRAITS)
+        typedef std::reverse_iterator<iterator> reverse_iterator;
+        typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+#elif defined(_MSC_VER) && (_MSC_VER == 1300) && defined(BOOST_DINKUMWARE_STDLIB) && (BOOST_DINKUMWARE_STDLIB == 310)
+        // workaround for broken reverse_iterator in VC7
+        typedef std::reverse_iterator<std::_Ptrit<value_type, difference_type, iterator,
+                                      reference, iterator, reference> > reverse_iterator;
+        typedef std::reverse_iterator<std::_Ptrit<value_type, difference_type, const_iterator,
+                                      const_reference, iterator, reference> > const_reverse_iterator;
+#else
+        // workaround for broken reverse_iterator implementations
+        typedef std::reverse_iterator<iterator,T> reverse_iterator;
+        typedef std::reverse_iterator<const_iterator,T> const_reverse_iterator;
+#endif
+
+        reverse_iterator rbegin() { return reverse_iterator(end()); }
+        const_reverse_iterator rbegin() const { return const_reverse_iterator(end()); }
+        reverse_iterator rend() { return reverse_iterator(begin()); }
+        const_reverse_iterator rend() const { return const_reverse_iterator(begin()); }
+        // operator[]
+        inline reference operator[](size_type i) { return elems[i]; }
+        inline const_reference operator[](size_type i) const { return elems[i]; }
+        // at() with range check
+        reference at(size_type i) { rangecheck(i); return elems[i]; }
+        const_reference at(size_type i) const { rangecheck(i); return elems[i]; }
+        // front() and back()
+        reference front() { return elems[0]; }
+        const_reference front() const { return elems[0]; }
+        reference back() { return elems[N-1]; }
+        const_reference back() const { return elems[N-1]; }
+        // size is constant
+        static inline size_type size() { return N; }
+        static bool empty() { return false; }
+        static size_type max_size() { return N; }
+        enum { static_size = N };
+		/** This method has no effects in this class, but raises an exception if the expected size does not match */
+		inline void resize(const size_t nElements) { if (nElements!=N) throw std::logic_error("Try to change the size of a CArray."); }
+        // swap (note: linear complexity in N, constant for given instantiation)
+        void swap (CArray<T,N>& y) { std::swap_ranges(begin(),end(),y.begin()); }
+        // direct access to data (read-only)
+        const T* data() const { return elems; }
+        // use array as C array (direct read/write access to data)
+        T* data() { return elems; }
+        // assignment with type conversion
+        template <typename T2> CArray<T,N>& operator= (const CArray<T2,N>& rhs) {
+            std::copy(rhs.begin(),rhs.end(), begin());
+            return *this;
+        }
+        // assign one value to all elements
+        inline void assign (const T& value) { for (size_t i=0;i<N;i++) elems[i]=value; }
+        // assign (compatible with std::vector's one) (by JLBC for MRPT)
+        void assign (const size_t n, const T& value) { assert(N==n); for (size_t i=0;i<N;i++) elems[i]=value; }
+      private:
+        // check range (may be private because it is static)
+        static void rangecheck (size_type i) { if (i >= size()) { throw std::out_of_range("CArray<>: index out of range"); } }
+    }; // end of CArray
+
+	/** Used to declare fixed-size arrays when DIM>0, dynamically-allocated vectors when DIM=-1.
+	  * Fixed size version for a generic DIM:
+	  */
+	template <int DIM, typename T>
+	struct array_or_vector_selector
+	{
+		typedef CArray<T, DIM> container_t;
+	};
+	/** Dynamic size version */
+	template <typename T>
+	struct array_or_vector_selector<-1, T> {
+		typedef std::vector<T> container_t;
+	};
+	
+	/** @} */
+
+	/** kd-tree base-class
+	 *
+	 * Contains the member functions common to the classes KDTreeSingleIndexAdaptor and KDTreeSingleIndexDynamicAdaptor_.
+	 *
+	 * \tparam Derived The name of the class which inherits this class.
+	 * \tparam DatasetAdaptor The user-provided adaptor (see comments above).
+	 * \tparam Distance The distance metric to use, these are all classes derived from nanoflann::Metric
+	 * \tparam DIM Dimensionality of data points (e.g. 3 for 3D points)
+	 * \tparam IndexType Will be typically size_t or int
+	 */
+
+	template<class Derived, typename Distance, class DatasetAdaptor, int DIM = -1, typename IndexType = size_t>
+	class KDTreeBaseClass
+	{
+
+	public:
+		/** Frees the previously-built index. Automatically called within buildIndex(). */
+		void freeIndex(Derived &obj)
+		{
+			obj.pool.free_all();
+			obj.root_node = NULL;
+			obj.m_size_at_index_build = 0;
+		}
+
+		typedef typename Distance::ElementType  ElementType;
+		typedef typename Distance::DistanceType DistanceType;
+
+		/*--------------------- Internal Data Structures --------------------------*/
+		struct Node
+		{
+			/** Union used because a node can be either a LEAF node or a non-leaf node, so both data fields are never used simultaneously */
+			union {
+				struct leaf
+                                {
+					IndexType    left, right;  //!< Indices of points in leaf node
+				} lr;
+				struct nonleaf
+                                {
+					int          divfeat; //!< Dimension used for subdivision.
+					DistanceType divlow, divhigh; //!< The values used for subdivision.
+				} sub;
+			} node_type;
+			Node *child1, *child2;  //!< Child nodes (both=NULL mean its a leaf node)
+		};
+		
+		typedef Node* NodePtr;
+
+		struct Interval
+		{
+			ElementType low, high;
+		};
+
+		/**
+		 *  Array of indices to vectors in the dataset.
+		 */
+		std::vector<IndexType> vind;
+
+		NodePtr root_node;
+
+		size_t m_leaf_max_size;
+
+		size_t m_size; //!< Number of current points in the dataset
+		size_t m_size_at_index_build; //!< Number of points in the dataset when the index was built
+		int dim;  //!< Dimensionality of each data point
+
+		/** Define "BoundingBox" as a fixed-size or variable-size container depending on "DIM" */
+		typedef typename array_or_vector_selector<DIM, Interval>::container_t BoundingBox;
+
+		/** Define "distance_vector_t" as a fixed-size or variable-size container depending on "DIM" */
+		typedef typename array_or_vector_selector<DIM, DistanceType>::container_t distance_vector_t;
+
+		/** The KD-tree used to find neighbours */
+		
+		BoundingBox root_bbox;
+
+		/**
+		 * Pooled memory allocator.
+		 *
+		 * Using a pooled memory allocator is more efficient
+		 * than allocating memory directly when there is a large
+		 * number small of memory allocations.
+		 */
+		PooledAllocator pool;
+
+		/** Returns number of points in dataset  */
+		size_t size(const Derived &obj) const { return obj.m_size; }
+
+		/** Returns the length of each point in the dataset */
+		size_t veclen(const Derived &obj) {
+			return static_cast<size_t>(DIM>0 ? DIM : obj.dim);
+		}
+
+		/// Helper accessor to the dataset points:
+		inline ElementType dataset_get(const Derived &obj, size_t idx, int component) const{
+			return obj.dataset.kdtree_get_pt(idx, component);
+		}
+
+		/**
+		 * Computes the inde memory usage
+		 * Returns: memory used by the index
+		 */
+		size_t usedMemory(Derived &obj)
+		{
+			return obj.pool.usedMemory + obj.pool.wastedMemory + obj.dataset.kdtree_get_point_count() * sizeof(IndexType);  // pool memory and vind array memory
+		}
+
+		void computeMinMax(const Derived &obj, IndexType* ind, IndexType count, int element, ElementType& min_elem, ElementType& max_elem)
+		{
+			min_elem = dataset_get(obj, ind[0],element);
+			max_elem = dataset_get(obj, ind[0],element);
+			for (IndexType i = 1; i < count; ++i) {
+				ElementType val = dataset_get(obj, ind[i], element);
+				if (val < min_elem) min_elem = val;
+				if (val > max_elem) max_elem = val;
+			}
+		}
+
+		/**
+		 * Create a tree node that subdivides the list of vecs from vind[first]
+		 * to vind[last].  The routine is called recursively on each sublist.
+		 *
+		 * @param left index of the first vector
+		 * @param right index of the last vector
+		 */
+		NodePtr divideTree(Derived &obj, const IndexType left, const IndexType right, BoundingBox& bbox)
+		{
+			NodePtr node = obj.pool.template allocate<Node>(); // allocate memory
+
+			/* If too few exemplars remain, then make this a leaf node. */
+			if ( (right - left) <= static_cast<IndexType>(obj.m_leaf_max_size) ) {
+				node->child1 = node->child2 = NULL;    /* Mark as leaf node. */
+				node->node_type.lr.left = left;
+				node->node_type.lr.right = right;
+
+				// compute bounding-box of leaf points
+				for (int i = 0; i < (DIM > 0 ? DIM : obj.dim); ++i) {
+					bbox[i].low = dataset_get(obj, obj.vind[left], i);
+					bbox[i].high = dataset_get(obj, obj.vind[left], i);
+				}
+				for (IndexType k = left + 1; k < right; ++k) {
+					for (int i = 0; i < (DIM > 0 ? DIM : obj.dim); ++i) {
+						if (bbox[i].low > dataset_get(obj, obj.vind[k], i)) bbox[i].low = dataset_get(obj, obj.vind[k], i);
+						if (bbox[i].high < dataset_get(obj, obj.vind[k], i)) bbox[i].high = dataset_get(obj, obj.vind[k], i);
+					}
+				}
+			}
+			else {
+				IndexType idx;
+				int cutfeat;
+				DistanceType cutval;
+				middleSplit_(obj, &obj.vind[0] + left, right - left, idx, cutfeat, cutval, bbox);
+
+				node->node_type.sub.divfeat = cutfeat;
+
+				BoundingBox left_bbox(bbox);
+				left_bbox[cutfeat].high = cutval;
+				node->child1 = divideTree(obj, left, left + idx, left_bbox);
+
+				BoundingBox right_bbox(bbox);
+				right_bbox[cutfeat].low = cutval;
+				node->child2 = divideTree(obj, left + idx, right, right_bbox);
+
+				node->node_type.sub.divlow = left_bbox[cutfeat].high;
+				node->node_type.sub.divhigh = right_bbox[cutfeat].low;
+
+				for (int i = 0; i < (DIM > 0 ? DIM : obj.dim); ++i) {
+					bbox[i].low = std::min(left_bbox[i].low, right_bbox[i].low);
+					bbox[i].high = std::max(left_bbox[i].high, right_bbox[i].high);
+				}
+			}
+
+			return node;
+		}
+
+		void middleSplit_(Derived &obj, IndexType* ind, IndexType count, IndexType& index, int& cutfeat, DistanceType& cutval, const BoundingBox& bbox)
+		{
+			const DistanceType EPS = static_cast<DistanceType>(0.00001);
+			ElementType max_span = bbox[0].high-bbox[0].low;
+			for (int i = 1; i < (DIM > 0 ? DIM : obj.dim); ++i) {
+				ElementType span = bbox[i].high - bbox[i].low;
+				if (span > max_span) {
+					max_span = span;
+				}
+			}
+			ElementType max_spread = -1;
+			cutfeat = 0;
+			for (int i = 0; i < (DIM > 0 ? DIM : obj.dim); ++i) {
+				ElementType span = bbox[i].high-bbox[i].low;
+				if (span > (1 - EPS) * max_span) {
+					ElementType min_elem, max_elem;
+					computeMinMax(obj, ind, count, i, min_elem, max_elem);
+					ElementType spread = max_elem - min_elem;;
+					if (spread > max_spread) {
+						cutfeat = i;
+						max_spread = spread;
+					}
+				}
+			}
+			// split in the middle
+			DistanceType split_val = (bbox[cutfeat].low + bbox[cutfeat].high) / 2;
+			ElementType min_elem, max_elem;
+			computeMinMax(obj, ind, count, cutfeat, min_elem, max_elem);
+
+			if (split_val < min_elem) cutval = min_elem;
+			else if (split_val > max_elem) cutval = max_elem;
+			else cutval = split_val;
+
+			IndexType lim1, lim2;
+			planeSplit(obj, ind, count, cutfeat, cutval, lim1, lim2);
+
+			if (lim1 > count / 2) index = lim1;
+			else if (lim2 < count / 2) index = lim2;
+			else index = count/2;
+		}
+
+		/**
+		 *  Subdivide the list of points by a plane perpendicular on axe corresponding
+		 *  to the 'cutfeat' dimension at 'cutval' position.
+		 *
+		 *  On return:
+		 *  dataset[ind[0..lim1-1]][cutfeat]<cutval
+		 *  dataset[ind[lim1..lim2-1]][cutfeat]==cutval
+		 *  dataset[ind[lim2..count]][cutfeat]>cutval
+		 */
+		void planeSplit(Derived &obj, IndexType* ind, const IndexType count, int cutfeat, DistanceType &cutval, IndexType& lim1, IndexType& lim2)
+		{
+			/* Move vector indices for left subtree to front of list. */
+			IndexType left = 0;
+			IndexType right = count-1;
+			for (;; ) {
+				while (left <= right && dataset_get(obj, ind[left], cutfeat) < cutval) ++left;
+				while (right && left <= right && dataset_get(obj, ind[right], cutfeat) >= cutval) --right;
+				if (left > right || !right) break;  // "!right" was added to support unsigned Index types
+				std::swap(ind[left], ind[right]);
+				++left;
+				--right;
+			}
+			/* If either list is empty, it means that all remaining features
+			 * are identical. Split in the middle to maintain a balanced tree.
+			 */
+			lim1 = left;
+			right = count-1;
+			for (;; ) {
+				while (left <= right && dataset_get(obj, ind[left], cutfeat) <= cutval) ++left;
+				while (right && left <= right && dataset_get(obj, ind[right], cutfeat) > cutval) --right;
+				if (left > right || !right) break;  // "!right" was added to support unsigned Index types
+				std::swap(ind[left], ind[right]);
+				++left;
+				--right;
+			}
+			lim2 = left;
+		}
+
+		DistanceType computeInitialDistances(const Derived &obj, const ElementType* vec, distance_vector_t& dists) const
+		{
+			assert(vec);
+			DistanceType distsq = DistanceType();
+
+			for (int i = 0; i < (DIM>0 ? DIM : obj.dim); ++i) {
+				if (vec[i] < obj.root_bbox[i].low) {
+					dists[i] = obj.distance.accum_dist(vec[i], obj.root_bbox[i].low, i);
+					distsq += dists[i];
+				}
+				if (vec[i] > obj.root_bbox[i].high) {
+					dists[i] = obj.distance.accum_dist(vec[i], obj.root_bbox[i].high, i);
+					distsq += dists[i];
+				}
+			}
+			return distsq;
+		}
+
+		void save_tree(Derived &obj, FILE* stream, NodePtr tree)
+		{
+			save_value(stream, *tree);
+			if (tree->child1 != NULL) {
+				save_tree(obj, stream, tree->child1);
+			}
+			if (tree->child2 != NULL) {
+				save_tree(obj, stream, tree->child2);
+			}
+		}
+
+
+		void load_tree(Derived &obj, FILE* stream, NodePtr& tree)
+		{
+			tree = obj.pool.template allocate<Node>();
+			load_value(stream, *tree);
+			if (tree->child1 != NULL) {
+				load_tree(obj, stream, tree->child1);
+			}
+			if (tree->child2 != NULL) {
+				load_tree(obj, stream, tree->child2);
+			}
+		}
+
+		/**  Stores the index in a binary file.
+		  *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so when loading the index object it must be constructed associated to the same source of data points used while building it.
+		  * See the example: examples/saveload_example.cpp
+		  * \sa loadIndex  */
+		void saveIndex_(Derived &obj, FILE* stream)
+		{
+			save_value(stream, obj.m_size);
+			save_value(stream, obj.dim);
+			save_value(stream, obj.root_bbox);
+			save_value(stream, obj.m_leaf_max_size);
+			save_value(stream, obj.vind);
+			save_tree(obj, stream, obj.root_node);
+		}
+
+		/**  Loads a previous index from a binary file.
+		  *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so the index object must be constructed associated to the same source of data points used while building the index.
+		  * See the example: examples/saveload_example.cpp
+		  * \sa loadIndex  */
+		void loadIndex_(Derived &obj, FILE* stream)
+		{
+			load_value(stream, obj.m_size);
+			load_value(stream, obj.dim);
+			load_value(stream, obj.root_bbox);
+			load_value(stream, obj.m_leaf_max_size);
+			load_value(stream, obj.vind);
+			load_tree(obj, stream, obj.root_node);
+		}
+
+	};
+
+
+	/** @addtogroup kdtrees_grp KD-tree classes and adaptors
+	  * @{ */
+
+	/** kd-tree static index
+	 *
+	 * Contains the k-d trees and other information for indexing a set of points
+	 * for nearest-neighbor matching.
+	 *
+	 *  The class "DatasetAdaptor" must provide the following interface (can be non-virtual, inlined methods):
+	 *
+	 *  \code
+	 *   // Must return the number of data poins
+	 *   inline size_t kdtree_get_point_count() const { ... }
+	 *
+	 *
+	 *   // Must return the dim'th component of the idx'th point in the class:
+	 *   inline T kdtree_get_pt(const size_t idx, int dim) const { ... }
+	 *
+	 *   // Optional bounding-box computation: return false to default to a standard bbox computation loop.
+	 *   //   Return true if the BBOX was already computed by the class and returned in "bb" so it can be avoided to redo it again.
+	 *   //   Look at bb.size() to find out the expected dimensionality (e.g. 2 or 3 for point clouds)
+	 *   template <class BBOX>
+	 *   bool kdtree_get_bbox(BBOX &bb) const
+	 *   {
+	 *      bb[0].low = ...; bb[0].high = ...;  // 0th dimension limits
+	 *      bb[1].low = ...; bb[1].high = ...;  // 1st dimension limits
+	 *      ...
+	 *      return true;
+	 *   }
+	 *
+	 *  \endcode
+	 *
+	 * \tparam DatasetAdaptor The user-provided adaptor (see comments above).
+	 * \tparam Distance The distance metric to use: nanoflann::metric_L1, nanoflann::metric_L2, nanoflann::metric_L2_Simple, etc.
+	 * \tparam DIM Dimensionality of data points (e.g. 3 for 3D points)
+	 * \tparam IndexType Will be typically size_t or int
+	 */
+	template <typename Distance, class DatasetAdaptor, int DIM = -1, typename IndexType = size_t>
+	class KDTreeSingleIndexAdaptor : public KDTreeBaseClass<KDTreeSingleIndexAdaptor<Distance, DatasetAdaptor, DIM, IndexType>, Distance, DatasetAdaptor, DIM, IndexType>
+	{
+	private:
+		/** Hidden copy constructor, to disallow copying indices (Not implemented) */
+		KDTreeSingleIndexAdaptor(const KDTreeSingleIndexAdaptor<Distance, DatasetAdaptor, DIM, IndexType>&);
+	public:
+		
+		/**
+		 * The dataset used by this index
+		 */
+		const DatasetAdaptor &dataset; //!< The source of our data
+
+		const KDTreeSingleIndexAdaptorParams index_params;
+
+		Distance distance;
+
+		typedef typename nanoflann::KDTreeBaseClass<nanoflann::KDTreeSingleIndexAdaptor<Distance, DatasetAdaptor, DIM, IndexType>, Distance, DatasetAdaptor, DIM, IndexType> BaseClassRef;
+
+		typedef typename BaseClassRef::ElementType ElementType;
+		typedef typename BaseClassRef::DistanceType DistanceType;
+
+		typedef typename BaseClassRef::Node Node;
+		typedef Node* NodePtr;
+
+		typedef typename BaseClassRef::Interval Interval;
+		/** Define "BoundingBox" as a fixed-size or variable-size container depending on "DIM" */
+		typedef typename BaseClassRef::BoundingBox BoundingBox;
+
+		/** Define "distance_vector_t" as a fixed-size or variable-size container depending on "DIM" */
+		typedef typename BaseClassRef::distance_vector_t distance_vector_t;
+
+		/**
+		 * KDTree constructor
+		 *
+		 * Refer to docs in README.md or online in https://github.com/jlblancoc/nanoflann
+		 *
+		 * The KD-Tree point dimension (the length of each point in the datase, e.g. 3 for 3D points)
+		 * is determined by means of:
+		 *  - The \a DIM template parameter if >0 (highest priority)
+		 *  - Otherwise, the \a dimensionality parameter of this constructor.
+		 *
+		 * @param inputData Dataset with the input features
+		 * @param params Basically, the maximum leaf node size
+		 */
+		KDTreeSingleIndexAdaptor(const int dimensionality, const DatasetAdaptor& inputData, const KDTreeSingleIndexAdaptorParams& params = KDTreeSingleIndexAdaptorParams() ) :
+			dataset(inputData), index_params(params), distance(inputData)
+		{
+			BaseClassRef::root_node = NULL;
+			BaseClassRef::m_size = dataset.kdtree_get_point_count();
+			BaseClassRef::m_size_at_index_build = BaseClassRef::m_size;
+			BaseClassRef::dim = dimensionality;
+			if (DIM>0) BaseClassRef::dim = DIM;
+			BaseClassRef::m_leaf_max_size = params.leaf_max_size;
+
+			// Create a permutable array of indices to the input vectors.
+			init_vind();
+		}
+
+		/**
+		 * Builds the index
+		 */
+		void buildIndex()
+		{
+			init_vind();
+			this->freeIndex(*this);
+			BaseClassRef::m_size_at_index_build = BaseClassRef::m_size;
+			if(BaseClassRef::m_size == 0) return;
+			computeBoundingBox(BaseClassRef::root_bbox);
+			BaseClassRef::root_node = this->divideTree(*this, 0, BaseClassRef::m_size, BaseClassRef::root_bbox );   // construct the tree
+		}
+
+		/** \name Query methods
+		  * @{ */
+
+		/**
+		 * Find set of nearest neighbors to vec[0:dim-1]. Their indices are stored inside
+		 * the result object.
+		 *
+		 * Params:
+		 *     result = the result object in which the indices of the nearest-neighbors are stored
+		 *     vec = the vector for which to search the nearest neighbors
+		 *
+		 * \tparam RESULTSET Should be any ResultSet<DistanceType>
+         * \return  True if the requested neighbors could be found.
+		 * \sa knnSearch, radiusSearch
+		 */
+		template <typename RESULTSET>
+		bool findNeighbors(RESULTSET& result, const ElementType* vec, const SearchParams& searchParams) const
+		{
+			assert(vec);
+            if (this->size(*this) == 0)
+                return false;
+			if (!BaseClassRef::root_node)
+                throw std::runtime_error("[nanoflann] findNeighbors() called before building the index.");
+			float epsError = 1 + searchParams.eps;
+
+			distance_vector_t dists; // fixed or variable-sized container (depending on DIM)
+			dists.assign((DIM > 0 ? DIM : BaseClassRef::dim), 0); // Fill it with zeros.
+			DistanceType distsq = this->computeInitialDistances(*this, vec, dists);
+			searchLevel(result, vec, BaseClassRef::root_node, distsq, dists, epsError);  // "count_leaf" parameter removed since was neither used nor returned to the user.
+            return result.full();
+		}
+
+		/**
+		 * Find the "num_closest" nearest neighbors to the \a query_point[0:dim-1]. Their indices are stored inside
+		 * the result object.
+		 *  \sa radiusSearch, findNeighbors
+		 * \note nChecks_IGNORED is ignored but kept for compatibility with the original FLANN interface.
+		 * \return Number `N` of valid points in the result set. Only the first `N` entries in `out_indices` and `out_distances_sq` will be valid.
+		 *         Return may be less than `num_closest` only if the number of elements in the tree is less than `num_closest`.
+		 */
+		size_t knnSearch(const ElementType *query_point, const size_t num_closest, IndexType *out_indices, DistanceType *out_distances_sq, const int /* nChecks_IGNORED */ = 10) const
+		{
+			nanoflann::KNNResultSet<DistanceType,IndexType> resultSet(num_closest);
+			resultSet.init(out_indices, out_distances_sq);
+			this->findNeighbors(resultSet, query_point, nanoflann::SearchParams());
+			return resultSet.size();
+		}
+
+		/**
+		 * Find all the neighbors to \a query_point[0:dim-1] within a maximum radius.
+		 *  The output is given as a vector of pairs, of which the first element is a point index and the second the corresponding distance.
+		 *  Previous contents of \a IndicesDists are cleared.
+		 *
+		 *  If searchParams.sorted==true, the output list is sorted by ascending distances.
+		 *
+		 *  For a better performance, it is advisable to do a .reserve() on the vector if you have any wild guess about the number of expected matches.
+		 *
+		 *  \sa knnSearch, findNeighbors, radiusSearchCustomCallback
+		 * \return The number of points within the given radius (i.e. indices.size() or dists.size() )
+		 */
+		size_t radiusSearch(const ElementType *query_point, const DistanceType &radius, std::vector<std::pair<IndexType, DistanceType> >& IndicesDists, const SearchParams& searchParams) const
+		{
+			RadiusResultSet<DistanceType, IndexType> resultSet(radius, IndicesDists);
+			const size_t nFound = radiusSearchCustomCallback(query_point, resultSet, searchParams);
+			if (searchParams.sorted)
+				std::sort(IndicesDists.begin(), IndicesDists.end(), IndexDist_Sorter() );
+			return nFound;
+		}
+
+		/**
+		 * Just like radiusSearch() but with a custom callback class for each point found in the radius of the query.
+		 * See the source of RadiusResultSet<> as a start point for your own classes.
+		 * \sa radiusSearch
+		 */
+		template <class SEARCH_CALLBACK>
+		size_t radiusSearchCustomCallback(const ElementType *query_point, SEARCH_CALLBACK &resultSet, const SearchParams& searchParams = SearchParams() ) const
+		{
+			this->findNeighbors(resultSet, query_point, searchParams);
+			return resultSet.size();
+		}
+
+		/** @} */
+
+	public:
+		/** Make sure the auxiliary list \a vind has the same size than the current dataset, and re-generate if size has changed. */
+		void init_vind()
+		{
+			// Create a permutable array of indices to the input vectors.
+			BaseClassRef::m_size = dataset.kdtree_get_point_count();
+			if (BaseClassRef::vind.size() != BaseClassRef::m_size) BaseClassRef::vind.resize(BaseClassRef::m_size);
+			for (size_t i = 0; i < BaseClassRef::m_size; i++) BaseClassRef::vind[i] = i;
+		}
+
+		void computeBoundingBox(BoundingBox& bbox)
+		{
+			bbox.resize((DIM > 0 ? DIM : BaseClassRef::dim));
+			if (dataset.kdtree_get_bbox(bbox))
+			{
+				// Done! It was implemented in derived class
+			}
+			else
+			{
+				const size_t N = dataset.kdtree_get_point_count();
+				if (!N) throw std::runtime_error("[nanoflann] computeBoundingBox() called but no data points found.");
+				for (int i = 0; i < (DIM > 0 ? DIM : BaseClassRef::dim); ++i) {
+					bbox[i].low =
+					bbox[i].high = this->dataset_get(*this, 0, i);
+				}
+				for (size_t k = 1; k < N; ++k) {
+					for (int i = 0; i < (DIM > 0 ? DIM : BaseClassRef::dim); ++i) {
+						if (this->dataset_get(*this, k, i) < bbox[i].low) bbox[i].low = this->dataset_get(*this, k, i);
+						if (this->dataset_get(*this, k, i) > bbox[i].high) bbox[i].high = this->dataset_get(*this, k, i);
+					}
+				}
+			}
+		}
+
+		/**
+		 * Performs an exact search in the tree starting from a node.
+		 * \tparam RESULTSET Should be any ResultSet<DistanceType>
+                 * \return true if the search should be continued, false if the results are sufficient
+		 */
+		template <class RESULTSET>
+                bool searchLevel(RESULTSET& result_set, const ElementType* vec, const NodePtr node, DistanceType mindistsq,
+						 distance_vector_t& dists, const float epsError) const
+		{
+			/* If this is a leaf node, then do check and return. */
+			if ((node->child1 == NULL) && (node->child2 == NULL)) {
+				//count_leaf += (node->lr.right-node->lr.left);  // Removed since was neither used nor returned to the user.
+				DistanceType worst_dist = result_set.worstDist();
+				for (IndexType i = node->node_type.lr.left; i<node->node_type.lr.right; ++i) {
+					const IndexType index = BaseClassRef::vind[i];// reorder... : i;
+					DistanceType dist = distance.evalMetric(vec, index, (DIM > 0 ? DIM : BaseClassRef::dim));
+					if (dist < worst_dist) {
+                                                if(!result_set.addPoint(dist, BaseClassRef::vind[i])) {
+                                                    // the resultset doesn't want to receive any more points, we're done searching!
+                                                    return false;
+                                                }
+					}
+				}
+                                return true;
+			}
+
+			/* Which child branch should be taken first? */
+			int idx = node->node_type.sub.divfeat;
+			ElementType val = vec[idx];
+			DistanceType diff1 = val - node->node_type.sub.divlow;
+			DistanceType diff2 = val - node->node_type.sub.divhigh;
+
+			NodePtr bestChild;
+			NodePtr otherChild;
+			DistanceType cut_dist;
+			if ((diff1 + diff2) < 0) {
+				bestChild = node->child1;
+				otherChild = node->child2;
+				cut_dist = distance.accum_dist(val, node->node_type.sub.divhigh, idx);
+			}
+			else {
+				bestChild = node->child2;
+				otherChild = node->child1;
+				cut_dist = distance.accum_dist( val, node->node_type.sub.divlow, idx);
+			}
+
+			/* Call recursively to search next level down. */
+                        if(!searchLevel(result_set, vec, bestChild, mindistsq, dists, epsError)) {
+                            // the resultset doesn't want to receive any more points, we're done searching!
+                            return false;
+                        }
+
+			DistanceType dst = dists[idx];
+			mindistsq = mindistsq + cut_dist - dst;
+			dists[idx] = cut_dist;
+			if (mindistsq*epsError <= result_set.worstDist()) {
+                            if(!searchLevel(result_set, vec, otherChild, mindistsq, dists, epsError)) {
+                                // the resultset doesn't want to receive any more points, we're done searching!
+                                return false;
+                            }
+			}
+			dists[idx] = dst;
+                        return true;
+		}
+
+	public:
+		/**  Stores the index in a binary file.
+		  *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so when loading the index object it must be constructed associated to the same source of data points used while building it.
+		  * See the example: examples/saveload_example.cpp
+		  * \sa loadIndex  */
+		void saveIndex(FILE* stream)
+		{
+			this->saveIndex_(*this, stream);
+		}
+
+		/**  Loads a previous index from a binary file.
+		  *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so the index object must be constructed associated to the same source of data points used while building the index.
+		  * See the example: examples/saveload_example.cpp
+		  * \sa loadIndex  */
+		void loadIndex(FILE* stream)
+		{
+			this->loadIndex_(*this, stream);
+		}
+
+	};   // class KDTree
+
+
+	/** kd-tree dynamic index
+	 *
+	 * Contains the k-d trees and other information for indexing a set of points
+	 * for nearest-neighbor matching.
+	 *
+	 *  The class "DatasetAdaptor" must provide the following interface (can be non-virtual, inlined methods):
+	 *
+	 *  \code
+	 *   // Must return the number of data poins
+	 *   inline size_t kdtree_get_point_count() const { ... }
+	 *
+	 *   // Must return the dim'th component of the idx'th point in the class:
+	 *   inline T kdtree_get_pt(const size_t idx, int dim) const { ... }
+	 *
+	 *   // Optional bounding-box computation: return false to default to a standard bbox computation loop.
+	 *   //   Return true if the BBOX was already computed by the class and returned in "bb" so it can be avoided to redo it again.
+	 *   //   Look at bb.size() to find out the expected dimensionality (e.g. 2 or 3 for point clouds)
+	 *   template <class BBOX>
+	 *   bool kdtree_get_bbox(BBOX &bb) const
+	 *   {
+	 *      bb[0].low = ...; bb[0].high = ...;  // 0th dimension limits
+	 *      bb[1].low = ...; bb[1].high = ...;  // 1st dimension limits
+	 *      ...
+	 *      return true;
+	 *   }
+	 *
+	 *  \endcode
+	 *
+	 * \tparam DatasetAdaptor The user-provided adaptor (see comments above).
+	 * \tparam Distance The distance metric to use: nanoflann::metric_L1, nanoflann::metric_L2, nanoflann::metric_L2_Simple, etc.
+	 * \tparam DIM Dimensionality of data points (e.g. 3 for 3D points)
+	 * \tparam IndexType Will be typically size_t or int
+	 */	 
+	template <typename Distance, class DatasetAdaptor, int DIM = -1, typename IndexType = size_t>
+	class KDTreeSingleIndexDynamicAdaptor_ : public KDTreeBaseClass<KDTreeSingleIndexDynamicAdaptor_<Distance, DatasetAdaptor, DIM, IndexType>, Distance, DatasetAdaptor, DIM, IndexType>
+	{
+	public:
+
+		/**
+		 * The dataset used by this index
+		 */
+		DatasetAdaptor &dataset; //!< The source of our data
+
+		KDTreeSingleIndexAdaptorParams index_params;
+
+		std::vector<int> &treeIndex;
+
+		Distance distance;
+
+		typedef typename nanoflann::KDTreeBaseClass<nanoflann::KDTreeSingleIndexDynamicAdaptor_<Distance, DatasetAdaptor, DIM, IndexType>, Distance, DatasetAdaptor, DIM, IndexType> BaseClassRef;
+
+		typedef typename BaseClassRef::ElementType  ElementType;
+		typedef typename BaseClassRef::DistanceType  DistanceType;
+
+		typedef typename BaseClassRef::Node Node;
+		typedef Node* NodePtr;
+
+		typedef typename BaseClassRef::Interval Interval;
+		/** Define "BoundingBox" as a fixed-size or variable-size container depending on "DIM" */
+		typedef typename BaseClassRef::BoundingBox BoundingBox;
+
+		/** Define "distance_vector_t" as a fixed-size or variable-size container depending on "DIM" */
+		typedef typename BaseClassRef::distance_vector_t distance_vector_t;
+
+		/**
+		 * KDTree constructor
+		 *
+		 * Refer to docs in README.md or online in https://github.com/jlblancoc/nanoflann
+		 *
+		 * The KD-Tree point dimension (the length of each point in the datase, e.g. 3 for 3D points)
+		 * is determined by means of:
+		 *  - The \a DIM template parameter if >0 (highest priority)
+		 *  - Otherwise, the \a dimensionality parameter of this constructor.
+		 *
+		 * @param inputData Dataset with the input features
+		 * @param params Basically, the maximum leaf node size
+		 */
+		KDTreeSingleIndexDynamicAdaptor_(const int dimensionality, DatasetAdaptor& inputData, std::vector<int>& treeIndex_, const KDTreeSingleIndexAdaptorParams& params = KDTreeSingleIndexAdaptorParams()) :
+			dataset(inputData), index_params(params), treeIndex(treeIndex_), distance(inputData)
+		{
+			BaseClassRef::root_node = NULL;
+			BaseClassRef::m_size = 0;
+			BaseClassRef::m_size_at_index_build = 0;
+			BaseClassRef::dim = dimensionality;
+			if (DIM>0) BaseClassRef::dim = DIM;
+			BaseClassRef::m_leaf_max_size = params.leaf_max_size;
+		}
+
+
+		/** Assignment operator definiton */
+		KDTreeSingleIndexDynamicAdaptor_ operator=( const KDTreeSingleIndexDynamicAdaptor_& rhs ) {
+		      KDTreeSingleIndexDynamicAdaptor_ tmp( rhs );
+		      std::swap( BaseClassRef::vind, tmp.BaseClassRef::vind );
+		      std::swap( BaseClassRef::m_leaf_max_size, tmp.BaseClassRef::m_leaf_max_size );
+		      std::swap( index_params, tmp.index_params );
+		      std::swap( treeIndex, tmp.treeIndex );
+		      std::swap( BaseClassRef::m_size, tmp.BaseClassRef::m_size );
+		      std::swap( BaseClassRef::m_size_at_index_build, tmp.BaseClassRef::m_size_at_index_build );
+		      std::swap( BaseClassRef::root_node, tmp.BaseClassRef::root_node );
+		      std::swap( BaseClassRef::root_bbox, tmp.BaseClassRef::root_bbox );
+		      std::swap( BaseClassRef::pool, tmp.BaseClassRef::pool );
+		      return *this;
+		 }
+
+		/**
+		 * Builds the index
+		 */
+		void buildIndex()
+		{
+			BaseClassRef::m_size = BaseClassRef::vind.size();
+			this->freeIndex(*this);
+			BaseClassRef::m_size_at_index_build = BaseClassRef::m_size;
+			if(BaseClassRef::m_size == 0) return;
+			computeBoundingBox(BaseClassRef::root_bbox);
+			BaseClassRef::root_node = this->divideTree(*this, 0, BaseClassRef::m_size, BaseClassRef::root_bbox );   // construct the tree
+		}
+
+		/** \name Query methods
+		  * @{ */
+
+		/**
+		 * Find set of nearest neighbors to vec[0:dim-1]. Their indices are stored inside
+		 * the result object.
+		 *
+		 * Params:
+		 *     result = the result object in which the indices of the nearest-neighbors are stored
+		 *     vec = the vector for which to search the nearest neighbors
+		 *
+		 * \tparam RESULTSET Should be any ResultSet<DistanceType>
+         * \return  True if the requested neighbors could be found.
+		 * \sa knnSearch, radiusSearch
+		 */
+		template <typename RESULTSET>
+		bool findNeighbors(RESULTSET& result, const ElementType* vec, const SearchParams& searchParams) const
+		{
+			assert(vec);
+            if (this->size(*this) == 0)
+                return false;
+			if (!BaseClassRef::root_node)
+                return false;
+			float epsError = 1 + searchParams.eps;
+
+			distance_vector_t dists; // fixed or variable-sized container (depending on DIM)
+			dists.assign((DIM > 0 ? DIM : BaseClassRef::dim) , 0); // Fill it with zeros.
+			DistanceType distsq = this->computeInitialDistances(*this, vec, dists);
+			searchLevel(result, vec, BaseClassRef::root_node, distsq, dists, epsError);  // "count_leaf" parameter removed since was neither used nor returned to the user.
+            return result.full();
+		}
+
+		/**
+		 * Find the "num_closest" nearest neighbors to the \a query_point[0:dim-1]. Their indices are stored inside
+		 * the result object.
+		 *  \sa radiusSearch, findNeighbors
+		 * \note nChecks_IGNORED is ignored but kept for compatibility with the original FLANN interface.
+		 * \return Number `N` of valid points in the result set. Only the first `N` entries in `out_indices` and `out_distances_sq` will be valid. 
+		 *         Return may be less than `num_closest` only if the number of elements in the tree is less than `num_closest`.
+		 */
+		size_t knnSearch(const ElementType *query_point, const size_t num_closest, IndexType *out_indices, DistanceType *out_distances_sq, const int /* nChecks_IGNORED */ = 10) const
+		{
+			nanoflann::KNNResultSet<DistanceType,IndexType> resultSet(num_closest);
+			resultSet.init(out_indices, out_distances_sq);
+			this->findNeighbors(resultSet, query_point, nanoflann::SearchParams());
+			return resultSet.size();
+		}
+
+		/**
+		 * Find all the neighbors to \a query_point[0:dim-1] within a maximum radius.
+		 *  The output is given as a vector of pairs, of which the first element is a point index and the second the corresponding distance.
+		 *  Previous contents of \a IndicesDists are cleared.
+		 *
+		 *  If searchParams.sorted==true, the output list is sorted by ascending distances.
+		 *
+		 *  For a better performance, it is advisable to do a .reserve() on the vector if you have any wild guess about the number of expected matches.
+		 *
+		 *  \sa knnSearch, findNeighbors, radiusSearchCustomCallback
+		 * \return The number of points within the given radius (i.e. indices.size() or dists.size() )
+		 */
+		size_t radiusSearch(const ElementType *query_point, const DistanceType &radius, std::vector<std::pair<IndexType,DistanceType> >& IndicesDists, const SearchParams& searchParams) const
+		{
+			RadiusResultSet<DistanceType,IndexType> resultSet(radius, IndicesDists);
+			const size_t nFound = radiusSearchCustomCallback(query_point, resultSet, searchParams);
+			if (searchParams.sorted)
+				std::sort(IndicesDists.begin(), IndicesDists.end(), IndexDist_Sorter() );
+			return nFound;
+		}
+
+		/**
+		 * Just like radiusSearch() but with a custom callback class for each point found in the radius of the query.
+		 * See the source of RadiusResultSet<> as a start point for your own classes.
+		 * \sa radiusSearch
+		 */
+		template <class SEARCH_CALLBACK>
+		size_t radiusSearchCustomCallback(const ElementType *query_point, SEARCH_CALLBACK &resultSet, const SearchParams& searchParams = SearchParams() ) const
+		{
+			this->findNeighbors(resultSet, query_point, searchParams);
+			return resultSet.size();
+		}
+
+		/** @} */
+
+	public:
+
+
+		void computeBoundingBox(BoundingBox& bbox)
+		{
+			bbox.resize((DIM > 0 ? DIM : BaseClassRef::dim));
+			if (dataset.kdtree_get_bbox(bbox))
+			{
+				// Done! It was implemented in derived class
+			}
+			else
+			{
+				const size_t N = BaseClassRef::m_size;
+				if (!N) throw std::runtime_error("[nanoflann] computeBoundingBox() called but no data points found.");
+				for (int i = 0; i < (DIM > 0 ? DIM : BaseClassRef::dim); ++i) {
+					bbox[i].low =
+					bbox[i].high = this->dataset_get(*this, BaseClassRef::vind[0], i);
+				}
+				for (size_t k = 1; k < N; ++k) {
+					for (int i = 0; i < (DIM > 0 ? DIM : BaseClassRef::dim); ++i) {
+						if (this->dataset_get(*this, BaseClassRef::vind[k], i) < bbox[i].low) bbox[i].low = this->dataset_get(*this, BaseClassRef::vind[k], i);
+						if (this->dataset_get(*this, BaseClassRef::vind[k], i) > bbox[i].high) bbox[i].high = this->dataset_get(*this, BaseClassRef::vind[k], i);
+					}
+				}
+			}
+		}
+
+		/**
+		 * Performs an exact search in the tree starting from a node.
+		 * \tparam RESULTSET Should be any ResultSet<DistanceType>
+		 */
+		template <class RESULTSET>
+		void searchLevel(RESULTSET& result_set, const ElementType* vec, const NodePtr node, DistanceType mindistsq,
+						 distance_vector_t& dists, const float epsError) const
+		{
+			/* If this is a leaf node, then do check and return. */
+			if ((node->child1 == NULL) && (node->child2 == NULL)) {
+				//count_leaf += (node->lr.right-node->lr.left);  // Removed since was neither used nor returned to the user.
+				DistanceType worst_dist = result_set.worstDist();
+				for (IndexType i = node->node_type.lr.left; i < node->node_type.lr.right; ++i) {
+					const IndexType index = BaseClassRef::vind[i];// reorder... : i;
+					if(treeIndex[index] == -1)
+						continue;
+					DistanceType dist = distance.evalMetric(vec, index, (DIM > 0 ? DIM : BaseClassRef::dim));
+					if (dist<worst_dist) {
+						result_set.addPoint(dist, BaseClassRef::vind[i]);
+					}
+				}
+				return;
+			}
+
+			/* Which child branch should be taken first? */
+			int idx = node->node_type.sub.divfeat;
+			ElementType val = vec[idx];
+			DistanceType diff1 = val - node->node_type.sub.divlow;
+			DistanceType diff2 = val - node->node_type.sub.divhigh;
+
+			NodePtr bestChild;
+			NodePtr otherChild;
+			DistanceType cut_dist;
+			if ((diff1 + diff2) < 0) {
+				bestChild = node->child1;
+				otherChild = node->child2;
+				cut_dist = distance.accum_dist(val, node->node_type.sub.divhigh, idx);
+			}
+			else {
+				bestChild = node->child2;
+				otherChild = node->child1;
+				cut_dist = distance.accum_dist( val, node->node_type.sub.divlow, idx);
+			}
+
+			/* Call recursively to search next level down. */
+			searchLevel(result_set, vec, bestChild, mindistsq, dists, epsError);
+
+			DistanceType dst = dists[idx];
+			mindistsq = mindistsq + cut_dist - dst;
+			dists[idx] = cut_dist;
+			if (mindistsq*epsError <= result_set.worstDist()) {
+				searchLevel(result_set, vec, otherChild, mindistsq, dists, epsError);
+			}
+			dists[idx] = dst;
+		}
+
+	public:
+		/**  Stores the index in a binary file.
+		  *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so when loading the index object it must be constructed associated to the same source of data points used while building it.
+		  * See the example: examples/saveload_example.cpp
+		  * \sa loadIndex  */
+		void saveIndex(FILE* stream)
+		{
+			this->saveIndex_(*this, stream);
+		}
+
+		/**  Loads a previous index from a binary file.
+		  *   IMPORTANT NOTE: The set of data points is NOT stored in the file, so the index object must be constructed associated to the same source of data points used while building the index.
+		  * See the example: examples/saveload_example.cpp
+		  * \sa loadIndex  */
+		void loadIndex(FILE* stream)
+		{
+			this->loadIndex_(*this, stream);
+		}
+
+	};
+
+
+	/** kd-tree dynaimic index
+	 *
+	 * class to create multiple static index and merge their results to behave as single dynamic index as proposed in Logarithmic Approach.
+	 *  
+	 *  Example of usage:
+	 *  examples/dynamic_pointcloud_example.cpp
+	 *
+	 * \tparam DatasetAdaptor The user-provided adaptor (see comments above).
+	 * \tparam Distance The distance metric to use: nanoflann::metric_L1, nanoflann::metric_L2, nanoflann::metric_L2_Simple, etc.
+	 * \tparam DIM Dimensionality of data points (e.g. 3 for 3D points)
+	 * \tparam IndexType Will be typically size_t or int
+	 */
+	template <typename Distance, class DatasetAdaptor,int DIM = -1, typename IndexType = size_t>
+	class KDTreeSingleIndexDynamicAdaptor
+	{
+	public:
+		typedef typename Distance::ElementType  ElementType;
+		typedef typename Distance::DistanceType DistanceType;
+	protected:
+
+		size_t m_leaf_max_size;
+		size_t treeCount;
+		size_t pointCount;
+
+		/**
+		 * The dataset used by this index
+		 */
+		DatasetAdaptor &dataset; //!< The source of our data
+
+		std::vector<int> treeIndex; //!< treeIndex[idx] is the index of tree in which point at idx is stored. treeIndex[idx]=-1 means that point has been removed.
+
+		KDTreeSingleIndexAdaptorParams index_params;
+
+		int dim;  //!< Dimensionality of each data point
+
+		typedef KDTreeSingleIndexDynamicAdaptor_<Distance, DatasetAdaptor, DIM> index_container_t;
+		std::vector<index_container_t> index;
+
+	public:
+		/** Get a const ref to the internal list of indices; the number of indices is adapted dynamically as 
+		  * the dataset grows in size. */
+		const std::vector<index_container_t> & getAllIndices() const {
+			return index;
+		}
+
+	private:
+		/** finds position of least significant unset bit */
+		int First0Bit(IndexType num)
+		{
+			int pos = 0;
+			while(num&1)
+			{
+				num = num>>1;
+				pos++;
+			}
+			return pos;
+		}
+
+		/** Creates multiple empty trees to handle dynamic support */
+		void init()
+		{
+			typedef KDTreeSingleIndexDynamicAdaptor_<Distance, DatasetAdaptor, DIM> my_kd_tree_t;
+			std::vector<my_kd_tree_t> index_(treeCount, my_kd_tree_t(dim /*dim*/, dataset, treeIndex, index_params));
+			index=index_;
+		}
+
+	public:
+
+		Distance distance;
+
+		/**
+		 * KDTree constructor
+		 *
+		 * Refer to docs in README.md or online in https://github.com/jlblancoc/nanoflann
+		 *
+		 * The KD-Tree point dimension (the length of each point in the datase, e.g. 3 for 3D points)
+		 * is determined by means of:
+		 *  - The \a DIM template parameter if >0 (highest priority)
+		 *  - Otherwise, the \a dimensionality parameter of this constructor.
+		 *
+		 * @param inputData Dataset with the input features
+		 * @param params Basically, the maximum leaf node size
+		 */
+		KDTreeSingleIndexDynamicAdaptor(const int dimensionality, DatasetAdaptor& inputData, const KDTreeSingleIndexAdaptorParams& params = KDTreeSingleIndexAdaptorParams() , const size_t maximumPointCount = 1000000000U) :
+			dataset(inputData), index_params(params), distance(inputData)
+		{
+			if (dataset.kdtree_get_point_count()) throw std::runtime_error("[nanoflann] cannot handle non empty point cloud.");
+			treeCount = log2(maximumPointCount);
+			pointCount = 0U;
+			dim = dimensionality;
+			treeIndex.clear();
+			if (DIM > 0) dim = DIM;
+			m_leaf_max_size = params.leaf_max_size;
+			init();
+		}
+
+
+		/** Add points to the set, Inserts all points from [start, end] */
+		void addPoints(IndexType start, IndexType end)
+		{
+			int count = end - start + 1;
+			treeIndex.resize(treeIndex.size() + count);
+			for(IndexType idx = start; idx <= end; idx++) {
+				int pos = First0Bit(pointCount);
+				index[pos].vind.clear();
+				treeIndex[pointCount]=pos;
+				for(int i = 0; i < pos; i++) {
+					for(int j = 0; j < index[i].vind.size(); j++) {
+						index[pos].vind.push_back(index[i].vind[j]);
+						treeIndex[index[i].vind[j]] = pos;
+					}
+					index[i].vind.clear();
+					index[i].freeIndex(index[i]);
+				}
+				index[pos].vind.push_back(idx);
+				index[pos].buildIndex();
+				pointCount++;
+			}
+		}
+
+		/** Remove a point from the set (Lazy Deletion) */
+		void removePoint(size_t idx)
+		{
+			if(idx >= pointCount)
+				return;
+			treeIndex[idx] = -1;
+		}
+
+		/**
+		 * Find set of nearest neighbors to vec[0:dim-1]. Their indices are stored inside
+		 * the result object.
+		 *
+		 * Params:
+		 *     result = the result object in which the indices of the nearest-neighbors are stored
+		 *     vec = the vector for which to search the nearest neighbors
+		 *
+		 * \tparam RESULTSET Should be any ResultSet<DistanceType>
+         * \return  True if the requested neighbors could be found.
+		 * \sa knnSearch, radiusSearch
+		 */
+		template <typename RESULTSET>
+		bool findNeighbors(RESULTSET& result, const ElementType* vec, const SearchParams& searchParams) const
+		{
+			for(size_t i = 0; i < treeCount; i++)
+			{
+				index[i].findNeighbors(result, &vec[0], searchParams);
+			}
+			return result.full();
+		}
+
+	}; 
+
+	/** An L2-metric KD-tree adaptor for working with data directly stored in an Eigen Matrix, without duplicating the data storage.
+	  *  Each row in the matrix represents a point in the state space.
+	  *
+	  *  Example of usage:
+	  * \code
+	  * 	Eigen::Matrix<num_t,Dynamic,Dynamic>  mat;
+	  * 	// Fill out "mat"...
+	  *
+	  * 	typedef KDTreeEigenMatrixAdaptor< Eigen::Matrix<num_t,Dynamic,Dynamic> >  my_kd_tree_t;
+	  * 	const int max_leaf = 10;
+	  * 	my_kd_tree_t   mat_index(mat, max_leaf );
+	  * 	mat_index.index->buildIndex();
+	  * 	mat_index.index->...
+	  * \endcode
+	  *
+	  *  \tparam DIM If set to >0, it specifies a compile-time fixed dimensionality for the points in the data set, allowing more compiler optimizations.
+	  *  \tparam Distance The distance metric to use: nanoflann::metric_L1, nanoflann::metric_L2, nanoflann::metric_L2_Simple, etc.
+	  */
+	template <class MatrixType, class Distance = nanoflann::metric_L2>
+	struct KDTreeEigenMatrixAdaptor
+	{
+		typedef KDTreeEigenMatrixAdaptor<MatrixType,Distance> self_t;
+		typedef typename MatrixType::Scalar              num_t;
+		typedef typename MatrixType::Index IndexType;
+		typedef typename Distance::template traits<num_t,self_t>::distance_t metric_t;
+		typedef KDTreeSingleIndexAdaptor< metric_t,self_t, MatrixType::ColsAtCompileTime,IndexType>  index_t;
+
+		index_t* index; //! The kd-tree index for the user to call its methods as usual with any other FLANN index.
+
+		/// Constructor: takes a const ref to the matrix object with the data points
+		KDTreeEigenMatrixAdaptor(const MatrixType &mat, const int leaf_max_size = 10) : m_data_matrix(mat)
+		{
+			const IndexType dims = mat.cols();
+			index = new index_t( dims, *this /* adaptor */, nanoflann::KDTreeSingleIndexAdaptorParams(leaf_max_size ) );
+			index->buildIndex();
+		}
+	private:
+		/** Hidden copy constructor, to disallow copying this class (Not implemented) */
+		KDTreeEigenMatrixAdaptor(const self_t&);
+	public:
+
+		~KDTreeEigenMatrixAdaptor() {
+			delete index;
+		}
+
+		const MatrixType &m_data_matrix;
+
+		/** Query for the \a num_closest closest points to a given point (entered as query_point[0:dim-1]).
+		  *  Note that this is a short-cut method for index->findNeighbors().
+		  *  The user can also call index->... methods as desired.
+		  * \note nChecks_IGNORED is ignored but kept for compatibility with the original FLANN interface.
+		  */
+		inline void query(const num_t *query_point, const size_t num_closest, IndexType *out_indices, num_t *out_distances_sq, const int /* nChecks_IGNORED */ = 10) const
+		{
+			nanoflann::KNNResultSet<num_t, IndexType> resultSet(num_closest);
+			resultSet.init(out_indices, out_distances_sq);
+			index->findNeighbors(resultSet, query_point, nanoflann::SearchParams());
+		}
+
+		/** @name Interface expected by KDTreeSingleIndexAdaptor
+		  * @{ */
+
+		const self_t & derived() const {
+			return *this;
+		}
+		self_t & derived()       {
+			return *this;
+		}
+
+		// Must return the number of data points
+		inline size_t kdtree_get_point_count() const {
+			return m_data_matrix.rows();
+		}
+
+		// Returns the L2 distance between the vector "p1[0:size-1]" and the data point with index "idx_p2" stored in the class:
+		inline num_t kdtree_distance(const num_t *p1, const IndexType idx_p2, IndexType size) const
+		{
+			num_t s = 0;
+			for (IndexType i = 0; i < size; i++) {
+				const num_t d = p1[i] - m_data_matrix.coeff(idx_p2, i);
+				s += d * d;
+			}
+			return s;
+		}
+
+		// Returns the dim'th component of the idx'th point in the class:
+		inline num_t kdtree_get_pt(const IndexType idx, int dim) const {
+			return m_data_matrix.coeff(idx, IndexType(dim));
+		}
+
+		// Optional bounding-box computation: return false to default to a standard bbox computation loop.
+		//   Return true if the BBOX was already computed by the class and returned in "bb" so it can be avoided to redo it again.
+		//   Look at bb.size() to find out the expected dimensionality (e.g. 2 or 3 for point clouds)
+		template <class BBOX>
+		bool kdtree_get_bbox(BBOX& /*bb*/) const {
+			return false;
+		}
+
+		/** @} */
+
+	}; // end of KDTreeEigenMatrixAdaptor
+	/** @} */
+
+/** @} */ // end of grouping
+} // end of NS
+
+
+#endif /* NANOFLANN_HPP_ */

--- a/include/mitsuba/core/spectrum.h
+++ b/include/mitsuba/core/spectrum.h
@@ -688,6 +688,13 @@ public:
     }
 #endif
 
+    inline bool hasNan()
+    {
+        for (int i = 0; i<SPECTRUM_SAMPLES; i++)
+            if (s[i] != s[i]) return true;
+        return false;
+    }
+
     /// Construct from a TSpectrum instance
     inline Spectrum(const Parent &s) : Parent(s) { }
 

--- a/include/mitsuba/render/bsdf.h
+++ b/include/mitsuba/render/bsdf.h
@@ -440,6 +440,9 @@ public:
     virtual Float pdf(const BSDFSamplingRecord &bRec,
         EMeasure measure = ESolidAngle) const = 0;
 
+    /// For given wi and component in bRec, return the probability of selecting the component
+    virtual Float selectionProb(const BSDFSamplingRecord &bRec) const;
+
     /**
      * \brief For transmissive BSDFs: return the material's
      * relative index of refraction

--- a/include/mitsuba/render/renderproc.h
+++ b/include/mitsuba/render/renderproc.h
@@ -90,6 +90,7 @@ protected:
     Bitmap::EPixelFormat m_pixelFormat;
     int m_channelCount;
     bool m_warnInvalid;
+    bool m_preserveProgress;
 };
 
 MTS_NAMESPACE_END

--- a/src/integrators/SConscript
+++ b/src/integrators/SConscript
@@ -40,4 +40,8 @@ plugins += bidirEnv.SharedLibrary('erpt',
         ['erpt/erpt.cpp', 'erpt/erpt_proc.cpp']
 )
 
+plugins += bidirEnv.SharedLibrary('vcm',
+        ['vcm/vcm.cpp', 'vcm/vcm_wr.cpp', 'vcm/vcm_proc.cpp']
+)
+
 Export('plugins')

--- a/src/integrators/pssmlt/pssmlt_sampler_base.h
+++ b/src/integrators/pssmlt/pssmlt_sampler_base.h
@@ -1,0 +1,284 @@
+/*
+    This file is part of Mitsuba, a physically based rendering system.
+
+    Copyright (c) 2007-2014 by Wenzel Jakob and others.
+
+    Mitsuba is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License Version 3
+    as published by the Free Software Foundation.
+
+    Mitsuba is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+/* 
+ * File:   pssmlt_sampler_base.h
+ * Author: swl
+ *
+ * Created on April 13, 2017, 11:17 PM
+ */
+
+#ifndef PSSMLT_SAMPLER_BASE_H
+#define PSSMLT_SAMPLER_BASE_H
+
+#include <mitsuba/render/sampler.h>
+#include <mitsuba/core/random.h>
+
+/// Use Kelemen-style mutations in random number space?
+#define MUTATION_STYLE 2
+// 0: KELEMEN  1: VEACH  2: TOSHIYA
+
+MTS_NAMESPACE_BEGIN
+
+class PSSMLTSamplerBase : public Sampler {
+public:
+    // Construct a new MLT sampler
+
+    PSSMLTSamplerBase(Float mutationSize) : Sampler(Properties()) {
+        m_random = new Random();
+        m_s1 = 1.0f/1024.0f;
+        m_s2 = 1.0f/64.0f;
+        configure();
+    }
+
+    /// Set whether the current step should be large
+
+    inline void setLargeStep(bool value) {
+        m_largeStep = value;
+    }
+
+    /// Check if the current step is a large step
+
+    inline bool isLargeStep() const {
+        return m_largeStep;
+    }
+
+    /// 1D mutation routine
+    inline void updateStepSize(const Float& s1, const Float& s2) {
+        m_s1 = s1;
+        m_s2 = s2;
+        m_logRatio = -math::fastlog(m_s2 / m_s1);
+    }
+    
+    inline void updateStrength(const Float& s) {
+        m_s1 = m_s2 * s;
+        m_logRatio = -math::fastlog(m_s2 / m_s1);
+    }
+    
+    inline Float getStrength() const {
+        return m_s1 / m_s2;
+    }
+
+    inline Float mutate(Float value) {
+#if MUTATION_STYLE == 0
+        Float sample = m_random->nextFloat();
+        bool add;
+
+        if (sample < 0.5f) {
+            add = true;
+            sample *= 2.0f;
+        } else {
+            add = false;
+            sample = 2.0f * (sample - 0.5f);
+        }
+
+        Float dv = m_s2 * math::fastexp(sample * m_logRatio);
+        if (add) {
+            value += dv;
+            if (value > 1)
+                value -= 1;
+        } else {
+            value -= dv;
+            if (value < 0)
+                value += 1;
+        }
+#elif MUTATION_STYLE == 1
+        Float tmp1 = std::sqrt(-2 * std::log(1 - m_random->nextFloat()));
+        Float dv = tmp1 * std::cos(2 * M_PI * m_random->nextFloat());
+        value = modulo(value + 1e-2f * dv, 1.0f);
+#else
+        Float sample = m_random->nextFloat();
+        if (sample < 0.5f) {
+            sample *= 2.0f;
+            value += pow(sample, m_s2 / m_s1 + 1.f);
+        } else {
+            sample = 2.0f * (sample - 0.5f);
+            value -= pow(sample, m_s2 / m_s1 + 1.f);
+        }
+        value -= floor(value);
+#endif
+        return value;
+    }
+
+    /// Replace the underlying random number generator
+
+    inline void setRandom(Random *random) {
+        m_random = random;
+    }
+
+    /// Return the underlying random number generator
+
+    inline Random *getRandom() {
+        return m_random;
+    }
+
+    /* The following functions do nothing in this implementation */
+    virtual void advance() {
+    }
+
+    virtual void generate(const Point2i &pos) {
+    }
+
+    /* The following functions are unsupported by this implementation */
+    void request1DArray(size_t size) {
+        Log(EError, "request1DArray(): Unsupported!");
+    }
+
+    void request2DArray(size_t size) {
+        Log(EError, "request2DArray(): Unsupported!");
+    }
+
+    void setSampleIndex(size_t sampleIndex) {
+        Log(EError, "setSampleIndex(): Unsupported!");
+    }
+
+    PSSMLTSamplerBase(PSSMLTSamplerBase *sampler) : Sampler(Properties()),
+    m_random(sampler->m_random) {
+        m_s1 = sampler->m_s1;
+        m_s2 = sampler->m_s2;
+        configure();
+    }
+
+    PSSMLTSamplerBase(Stream *stream, InstanceManager *manager)
+    : Sampler(stream, manager) {
+        m_random = static_cast<Random *> (manager->getInstance(stream));
+        m_s1 = stream->readFloat();
+        m_s2 = stream->readFloat();
+        configure();
+    }
+
+    void serialize(Stream *stream, InstanceManager *manager) const {
+        Sampler::serialize(stream, manager);
+        manager->serialize(stream, m_random.get());
+        stream->writeFloat(m_s1);
+        stream->writeFloat(m_s2);
+    }
+
+    void configure() {
+        m_logRatio = -math::fastlog(m_s2 / m_s1);
+        m_time = 0;
+        m_largeStepTime = 0;
+        m_largeStep = false;
+        m_sampleIndex = 0;
+        m_sampleCount = 0;
+    }
+
+    void reset() {
+        m_time = m_sampleIndex = m_largeStepTime = 0;
+        m_u.clear();
+    }
+    
+    void accept() {
+        if (m_largeStep)
+            m_largeStepTime = m_time;
+        m_time++;
+        m_backup.clear();
+        m_sampleIndex = 0;
+    }
+
+    void reject() {
+        for (size_t i = 0; i < m_backup.size(); ++i)
+            m_u[m_backup[i].first] = m_backup[i].second;
+        m_backup.clear();
+        m_sampleIndex = 0;
+    }
+
+    Float primarySample(size_t i) {
+        while (i >= m_u.size())
+            m_u.push_back(SampleStruct(m_random->nextFloat()));
+
+        if (m_u[i].modify < m_time) {
+            if (m_largeStep) {
+                m_backup.push_back(std::pair<size_t, SampleStruct>(i, m_u[i]));
+                m_u[i].modify = m_time;
+                m_u[i].value = m_random->nextFloat();
+            } else {
+                if (m_u[i].modify < m_largeStepTime) {
+                    m_u[i].modify = m_largeStepTime;
+                    m_u[i].value = m_random->nextFloat();
+                }
+
+                while (m_u[i].modify + 1 < m_time) {
+                    m_u[i].value = mutate(m_u[i].value);
+                    m_u[i].modify++;
+                }
+
+                m_backup.push_back(std::pair<size_t, SampleStruct>(i, m_u[i]));
+
+                m_u[i].value = mutate(m_u[i].value);
+                m_u[i].modify++;
+            }
+        }
+
+        return m_u[i].value;
+    }
+
+    ref<Sampler> clone() {
+        ref<PSSMLTSamplerBase> sampler = new PSSMLTSamplerBase(this);
+        sampler->m_sampleCount = m_sampleCount;
+        sampler->m_sampleIndex = m_sampleIndex;
+        sampler->m_random = new Random(m_random);
+        return sampler.get();
+    }
+
+    Float next1D() {
+        return primarySample(m_sampleIndex++);
+    }
+
+    Point2 next2D() {
+        /// Enforce a specific order of evaluation
+        Float value1 = primarySample(m_sampleIndex++);
+        Float value2 = primarySample(m_sampleIndex++);
+        return Point2(value1, value2);
+    }
+
+    std::string toString() const {
+        std::ostringstream oss;
+        oss << "PSSMLTSampler[" << endl
+                << "  sampleCount = " << m_sampleCount << endl
+                << "]";
+        return oss.str();
+    }
+
+protected:
+    /// Virtual destructor
+    virtual ~PSSMLTSamplerBase() {
+    }
+protected:
+
+    struct SampleStruct {
+        Float value;
+        size_t modify;
+
+        inline SampleStruct(Float value) : value(value), modify(0) {
+        }
+    };
+
+    ref<Random> m_random;
+    Float m_s1, m_s2, m_logRatio;
+    bool m_largeStep;
+    std::vector<std::pair<size_t, SampleStruct> > m_backup;
+    std::vector<SampleStruct> m_u;
+    size_t m_time, m_largeStepTime;
+    Float m_probLargeStep;
+};
+
+MTS_NAMESPACE_END
+
+#endif /* PSSMLT_SAMPLER_BASE_H */
+

--- a/src/integrators/vcm/vcm.cpp
+++ b/src/integrators/vcm/vcm.cpp
@@ -1,0 +1,284 @@
+/*
+    This file is part of Mitsuba, a physically based rendering system.
+
+    Copyright (c) 2007-2014 by Wenzel Jakob and others.
+
+    Mitsuba is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License Version 3
+    as published by the Free Software Foundation.
+
+    Mitsuba is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <mitsuba/core/plugin.h>
+#include <mitsuba/bidir/vertex.h>
+#include <mitsuba/bidir/edge.h>
+#include "vcm_proc.h"
+
+#if defined(MTS_OPENMP)
+#include <omp.h>
+#endif
+
+MTS_NAMESPACE_BEGIN
+
+/*!\plugin{bdpt}{Bidirectional path tracer}
+ * \order{5}
+ * \parameters{
+ *     \parameter{maxDepth}{\Integer}{Specifies the longest path depth
+ *         in the generated output image (where \code{-1} corresponds to $\infty$).
+ *	       A value of \code{1} will only render directly visible light sources.
+ *	       \code{2} will lead to single-bounce (direct-only) illumination,
+ *	       and so on. \default{\code{-1}}
+ *	   }
+ *	   \parameter{lightImage}{\Boolean}{Include sampling strategies that connect
+ *	      paths traced from emitters directly to the camera? (i.e. what \pluginref{ptracer} does)
+ *	      This improves the effectiveness of bidirectional path tracing
+ *	      but severely increases the local and remote communication
+ *	      overhead, since large \emph{light images} must be transferred between threads
+ *	      or over the network. See the text below for a more detailed explanation.
+ *	      \default{include these strategies, i.e. \code{true}}
+ *     }
+ *     \parameter{sampleDirect}{\Boolean}{Enable direct sampling strategies? This is a generalization
+ *        of direct illumination sampling that works with both emitters and sensors. Usually a good idea.
+ *        \default{use direct sampling, i.e. \code{true}}}
+ *	   \parameter{rrDepth}{\Integer}{Specifies the minimum path depth, after
+ *	      which the implementation will start to use the ``russian roulette''
+ *	      path termination criterion. \default{\code{5}}
+ *	   }
+ * }
+ *
+ ** \renderings{
+ *     \rendering{Path tracer, 32 samples/pixel}{integrator_bdpt_path}
+ *     \rendering{Bidirectional path tracer, 32 samples/pixel}{integrator_bdpt_bdpt}
+ *     \caption{
+ *     	The bidirectional path tracer finds light paths by generating partial
+ *     	paths starting at the emitters and the sensor and connecting them in every possible way.
+ *     	This works particularly well in closed scenes as the one shown above. Here, the unidirectional
+ *     	path tracer has severe difficulties finding some of the indirect illumination paths.
+ *     	Modeled after a scene by Eric Veach.
+ *     }
+ * }
+ * \renderings{
+ *    \includegraphics[width=12cm]{images/integrator_bdpt_sketch.pdf}\hfill\,
+ *    \caption{The four different ways in which VCM can create a direct illumination
+ *    path (matching the first row on the next page): \textbf{(a)} Standard path
+ *    tracing without direct illumination sampling, \textbf{(b)} path tracing with
+ *    direct illumination sampling, \textbf{(c)} Particle tracing with recording of
+ *    scattering events observed by the sensor, \textbf{(d)} Particle tracing with
+ *    recording of particles that hit the sensor.}\vspace{-3mm}
+ * }
+ * \renderings{
+ *     \unframedbigrendering{The individual sampling strategies that comprise VCM, but
+ *     \emph{without} multiple importance sampling. $s$ denotes the number of steps
+ *     taken from the emitters, and $t$ denotes the number of steps from the sensor.
+ *     Note how almost every strategy has deficiencies of some kind} {integrator_bdpt_unweighted.pdf}
+ *     \unframedbigrendering{The same sampling strategies, but now weighted using multiple importance
+ *     sampling---effectively ``turning off'' each strategy where it does not perform well.
+ *     The final result is computed by summing all of these images.}{integrator_bdpt_weighted.pdf}
+ * }
+ *
+ * This plugin implements a bidirectional path tracer (short: VCM) with support for multiple
+ * importance sampling, as proposed by Veach and Guibas \cite{Veach1994Bidirectional}.
+ *
+ * A bidirectional path tracer computes radiance estimates by starting two separate
+ * random walks from an emitter and a sensor. The resulting \emph{subpaths} are
+ * connected at every possible interaction vertex, creating a large number of complete paths
+ * of different lengths. These paths are then used to estimate the amount of
+ * radiance that is transferred from the emitter to a pixel on the sensor.
+ *
+ * Generally, some of the created paths will be undesirable, since they lead to
+ * high-variance radiance estimates. To alleviate this situation, VCM makes
+ * use of \emph{multiple importance sampling} which, roughly speaking, weights
+ * paths based on their predicted utility.
+ *
+ * The bidirectional path tracer in Mitsuba is a complete implementation of the
+ * technique that handles all sampling strategies, including those that involve
+ * direct interactions with the sensor. For this purpose, finite-aperture sensors
+ * are explicitly represented by surfaces in the scene so that they can be
+ * intersected by random walks started at emitters.
+ *
+ * Bidirectional path tracing is a relatively ``heavy'' rendering technique---for
+ * the same number of samples per pixel, it is easily 3-4 times slower than regular
+ * path tracing. However, it usually makes up for this by producing considerably
+ * lower-variance radiance estimates (i.e. the output images have less noise).
+ *
+ * The code parallelizes over multiple cores and machines, but with one caveat:
+ * some of the VCM path sampling strategies are incompatble with the usual
+ * approach of rendering an image tile by tile, since they can potentially
+ * contribute to \emph{any} pixel on the screen. This means that each
+ * rendering work unit must be associated with a full-sized image!
+ * When network render nodes are involved or the resolution of this \emph{light image}
+ * is very high, a bottleneck can arise where more work is spent  accumulating or
+ * transmitting these images than actual rendering.
+ *
+ * There are two possible resorts should this situation arise: the first one
+ * is to reduce the number of work units so that there is approximately one
+ * unit per core (and hence one image to transmit per core). This can be done by
+ * increasing the block size in the GUI preferences or passing the \code{-b}
+ * parameter to the \code{mitsuba} executable. The second option is to simply
+ * disable these sampling strategies at the cost of reducing the
+ * effectiveness of bidirectional path tracing (particularly, when rendering
+ * caustics). For this, set \code{lightImage} to \code{false}.
+ * When rendering an image of a reasonable resolution without network nodes,
+ * this is not a big concern, hence these strategies are enabled by default.
+ *
+ * \remarks{
+ *    \item This integrator does not work with dipole-style subsurface
+ *    scattering models.
+ *    \item This integrator does not yet work with certain non-reciprocal BSDFs (i.e.
+ *          \pluginref{bumpmap}, but this will be addressed in the future
+ * }
+ */
+class VCMIntegrator : public VCMIntegratorBase {
+public:
+
+    VCMIntegrator(const Properties &props) : VCMIntegratorBase(props) {
+        /* Load the parameters / defaults */
+        m_config.maxDepth = props.getInteger("maxDepth", -1);
+        m_config.rrDepth = props.getInteger("rrDepth", 5);
+        m_config.phExponent = props.getFloat("phExponent", 1.0);
+        m_config.lightImage = props.getBoolean("lightImage", true);
+        m_config.sampleDirect = props.getBoolean("sampleDirect", false); // Direct sampling is not supported yet.
+        m_config.showWeighted = props.getBoolean("showWeighted", false);
+        m_config.initialRadius = props.getFloat("initialRadius", 0.f);
+        m_config.radiusReductionAlpha = props.getFloat("radiusReductionAlpha", 0.95f);
+        m_config.mergeOnly = props.getBoolean("mergeOnly", false);
+        m_config.metropolis = props.getBoolean("metropolis", false);
+        if (m_config.mergeOnly) m_config.lightImage = false;
+        if (m_config.metropolis) m_config.lightImage = true;
+
+#if VCM_DEBUG == 1
+        if (m_config.maxDepth == -1 || m_config.maxDepth > 6) {
+            /* Limit the maximum depth when rendering image
+               matrices in VCM debug mode (the number of
+               these images grows quadratically with depth) */
+            Log(EWarn, "Limiting max. path depth to 6 to avoid an "
+                    "extremely large number of debug output images");
+            m_config.maxDepth = 6;
+        }
+#endif
+
+        if (m_config.rrDepth <= 0)
+            Log(EError, "'rrDepth' must be set to a value greater than zero!");
+
+        if (m_config.maxDepth <= 0 && m_config.maxDepth != -1)
+            Log(EError, "'maxDepth' must be set to -1 (infinite) or a value greater than zero!");
+    }
+
+    /// Unserialize from a binary data stream
+
+    VCMIntegrator(Stream *stream, InstanceManager *manager)
+    : VCMIntegratorBase(stream, manager) {
+        m_config = VCMConfiguration(stream);
+    }
+
+    void serialize(Stream *stream, InstanceManager *manager) const {
+        Integrator::serialize(stream, manager);
+        m_config.serialize(stream);
+    }
+
+    bool preprocess(const Scene *scene, RenderQueue *queue,
+            const RenderJob *job, int sceneResID, int sensorResID,
+            int samplerResID) {
+        Integrator::preprocess(scene, queue, job, sceneResID,
+                sensorResID, samplerResID);
+
+        if (scene->getSubsurfaceIntegrators().size() > 0)
+            Log(EError, "Subsurface integrators are not supported "
+                "by the bidirectional path tracer!");
+        if (m_config.initialRadius == 0) {
+            /* Guess an initial radius if not provided
+              (scene width / horizontal or vertical pixel count) * 5 */
+            Float rad = scene->getBSphere().radius;
+            Vector2i filmSize = scene->getSensor()->getFilm()->getSize();
+
+            m_config.initialRadius = std::min(rad / filmSize.x, rad / filmSize.y) * 5;
+        }
+
+        return true;
+    }
+
+    void cancel() {
+        m_cancelled = true;
+        Scheduler::getInstance()->cancel(m_process);
+    }
+
+    void configureSampler(const Scene *scene, Sampler *sampler) {
+        /* Prepare the sampler for tile-based rendering */
+        sampler->setFilmResolution(scene->getFilm()->getCropSize(), true);
+    }
+
+    bool render(Scene *scene, RenderQueue *queue, const RenderJob *job,
+            int sceneResID, int sensorResID, int samplerResID) {
+        ref<Scheduler> scheduler = Scheduler::getInstance();
+        ref<Sensor> sensor = scene->getSensor();
+        const Film *film = sensor->getFilm();
+        size_t sampleCount = scene->getSampler()->getSampleCount();
+        size_t nCores = scheduler->getCoreCount();
+
+        Log(EDebug, "Size of data structures: PathVertex=%i bytes, PathEdge=%i bytes",
+                (int) sizeof (PathVertex), (int) sizeof (PathEdge));
+
+        Log(EInfo, "Starting render job (%ix%i, " SIZE_T_FMT " samples, " SIZE_T_FMT
+                " %s, " SSE_STR ") ..", film->getCropSize().x, film->getCropSize().y,
+                sampleCount, nCores, nCores == 1 ? "core" : "cores");
+
+        m_config.blockSize = scene->getBlockSize();
+        m_config.cropSize = film->getCropSize();
+        m_config.sampleCount = sampleCount;
+        m_config.dump();
+
+        ref<Scene> bidir_scene = new Scene(scene);
+        bidir_scene->initializeBidirectional();
+        int bidirSceneResID = scheduler->registerResource(bidir_scene);
+
+        ref<VCMProcess> process = new VCMProcess(job, queue, m_config);
+        process->bindResource("scene", bidirSceneResID);
+        process->bindResource("sampler", samplerResID);
+        m_process = process;
+        m_cancelled = false;
+#if defined(MTS_OPENMP)
+        Thread::initializeOpenMP(nCores);
+#endif
+        /* Create a sampler instance for each worker */
+        ref<PSSMLTSamplerBase> mltSampler = new PSSMLTSamplerBase(1.0);
+        std::vector<SerializableObject *> mltSamplers(scheduler->getCoreCount());
+        for (size_t i = 0; i < mltSamplers.size(); ++i) {
+            ref<Sampler> clonedSampler = mltSampler->clone();
+            clonedSampler->incRef();
+            mltSamplers[i] = clonedSampler.get();
+        }
+        int mltSamplerResID = scheduler->registerMultiResource(mltSamplers);
+        process->bindResource("mltSampler", mltSamplerResID);
+
+        for (size_t i = 0; i < sampleCount; i++) {
+            if (iterateVCM(process, sensorResID, i) == false) break;
+        }
+        scheduler->unregisterResource(bidirSceneResID);
+        scheduler->unregisterResource(mltSamplerResID);
+        m_process = NULL;
+        process->develop();
+
+#if VCM_DEBUG == 1
+        fs::path path = scene->getDestinationFile();
+        if (m_config.lightImage)
+            process->getResult()->dump(m_config, path.parent_path(), path.stem());
+#endif
+        return process->getReturnStatus() == ParallelProcess::ESuccess;
+    }
+
+    MTS_DECLARE_CLASS()
+private:
+    ref<ParallelProcess> m_process;
+    VCMConfiguration m_config;
+};
+
+MTS_IMPLEMENT_CLASS_S(VCMIntegrator, false, Integrator)
+MTS_EXPORT_PLUGIN(VCMIntegrator, "Bidirectional path tracer");
+MTS_NAMESPACE_END

--- a/src/integrators/vcm/vcm.h
+++ b/src/integrators/vcm/vcm.h
@@ -1,0 +1,106 @@
+/*
+    This file is part of Mitsuba, a physically based rendering system.
+
+    Copyright (c) 2007-2014 by Wenzel Jakob and others.
+
+    Mitsuba is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License Version 3
+    as published by the Free Software Foundation.
+
+    Mitsuba is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#if !defined(__VCM_H)
+#define __VCM_H
+
+#include <mitsuba/mitsuba.h>
+#include "vcm_basics.h"
+/**
+ * When the following is set to "1", the Bidirectional Path Tracer
+ * will generate a series of debugging images that split up the final
+ * rendering into the weighted contributions of the individual sampling
+ * strategies.
+ */
+//#define VCM_DEBUG 1
+
+MTS_NAMESPACE_BEGIN
+
+/* ==================================================================== */
+/*                         Configuration storage                        */
+/* ==================================================================== */
+
+/**
+ * \brief Stores all configuration parameters of the
+ * bidirectional path tracer
+ */
+struct VCMConfiguration : public VCMConfigBase {
+	int blockSize, borderSize;
+	bool lightImage;
+	bool sampleDirect;
+	bool showWeighted;
+	size_t sampleCount;
+	Vector2i cropSize;
+        Float initialRadius;
+        Float radiusReductionAlpha;
+        bool mergeOnly;
+        
+
+	inline VCMConfiguration() { }
+
+	inline VCMConfiguration(Stream *stream) {
+		maxDepth = stream->readInt();
+		blockSize = stream->readInt();
+		lightImage = stream->readBool();
+		sampleDirect = stream->readBool();
+		showWeighted = stream->readBool();
+		sampleCount = stream->readSize();
+		cropSize = Vector2i(stream);
+		rrDepth = stream->readInt();
+                initialRadius = stream->readFloat();
+                radiusReductionAlpha = stream->readFloat();
+                phExponent = stream->readFloat();
+                mergeOnly = stream->readSize();
+	}
+
+	inline void serialize(Stream *stream) const {
+		stream->writeInt(maxDepth);
+		stream->writeInt(blockSize);
+		stream->writeBool(lightImage);
+		stream->writeBool(sampleDirect);
+		stream->writeBool(showWeighted);
+		stream->writeSize(sampleCount);
+		cropSize.serialize(stream);
+		stream->writeInt(rrDepth);
+                stream->writeFloat(initialRadius);
+                stream->writeFloat(radiusReductionAlpha);
+                stream->writeFloat(phExponent);
+                stream->writeBool(mergeOnly);
+	}
+
+	void dump() const {
+		SLog(EDebug, "Bidirectional path tracer configuration:");
+		SLog(EDebug, "   Maximum path depth          : %i", maxDepth);
+		SLog(EDebug, "   Image size                  : %ix%i",
+			cropSize.x, cropSize.y);
+		SLog(EDebug, "   Direct sampling strategies  : %s",
+			sampleDirect ? "yes" : "no");
+		SLog(EDebug, "   Generate light image        : %s",
+			lightImage ? "yes" : "no");
+		SLog(EDebug, "   Russian roulette depth      : %i", rrDepth);
+		SLog(EDebug, "   Block size                  : %i", blockSize);
+		SLog(EDebug, "   Number of samples           : " SIZE_T_FMT, sampleCount);
+		#if VCM_DEBUG == 1
+			SLog(EDebug, "   Show weighted contributions : %s", showWeighted ? "yes" : "no");
+		#endif
+	}
+};
+
+MTS_NAMESPACE_END
+
+#endif /* __VCM_H */

--- a/src/integrators/vcm/vcm_basics.h
+++ b/src/integrators/vcm/vcm_basics.h
@@ -1,0 +1,412 @@
+/*
+    This file is part of Mitsuba, a physically based rendering system.
+
+    Copyright (c) 2007-2014 by Wenzel Jakob and others.
+
+    Mitsuba is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License Version 3
+    as published by the Free Software Foundation.
+
+    Mitsuba is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if !defined(__VCM_BASICS_H)
+#define __VCM_BASICS_H
+
+#include <mitsuba/core/plugin.h>
+#include <mitsuba/render/renderproc.h>
+#include <mitsuba/render/renderjob.h>
+#include <mitsuba/core/bitmap.h>
+#include <mitsuba/core/sfcurve.h>
+#include <mitsuba/bidir/path.h>
+#include "../pssmlt/pssmlt_sampler_base.h"
+
+#if defined(MTS_OPENMP)
+#define NANOFLANN_USE_OMP
+#endif
+#include <mitsuba/core/nanoflann.h>
+
+MTS_NAMESPACE_BEGIN
+
+/* ==================================================================== */
+/*                           Parallel process                           */
+/* ==================================================================== */
+
+/**
+ * \brief Renders work units (rectangular image regions) using
+ * bidirectional path tracing
+ */
+
+struct VCMPhoton {
+    size_t blockID;
+    size_t pointID;
+    size_t vertexID;
+    Point3 pos;
+    float radius;
+};
+
+struct VCMPhotonMap {
+    std::vector<VCMPhoton> photons;
+
+    inline size_t kdtree_get_point_count() const {
+        return photons.size();
+    }
+
+    inline Float kdtree_distance(const Float* p1, const size_t idx_p2, size_t) const {
+        const Float d0 = p1[0] - photons[idx_p2].pos[0];
+        const Float d1 = p1[1] - photons[idx_p2].pos[1];
+        const Float d2 = p1[2] - photons[idx_p2].pos[2];
+        Float sqr_dist = d0 * d0 + d1 * d1 + d2 * d2;
+        return sqr_dist;
+    }
+
+    inline Float kdtree_get_pt(const size_t idx, int dim) const {
+        return photons[idx].pos[dim];
+    }
+
+    inline VCMPhoton& kdtree_get_data(const size_t idx) {
+        return photons[idx];
+    }
+
+    template <class BBOX>
+    bool kdtree_get_bbox(BBOX& /* bb */) const {
+        return false;
+    }
+};
+
+inline size_t ceil_div(size_t a, size_t b) {
+    return (a + b - 1) / b;
+}
+
+struct VCMStat {
+    Float value;
+    unsigned count;
+
+    VCMStat() {
+        value = 0.f;
+        count = 0;
+    }
+
+    void accumulate(Float v, unsigned c) {
+        if(c == 0) return;
+        value *= count / Float(c + count);
+        value += v * c / Float(c + count);
+        count += c;
+    }
+};
+
+class VCMWorkResultBase : public WorkResult {
+    using WorkResult::WorkResult;
+public:
+
+    inline void clearPhotons() {
+        m_photonMap.clear();
+    }
+
+    inline void putPhoton(const VCMPhoton& photon) {
+        m_photonMap.push_back(photon);
+    }
+
+    inline const std::vector<VCMPhoton>& getPhotons() const {
+        return m_photonMap;
+    }
+    virtual void setSize(const Vector2i &size) = 0;
+
+    virtual void setOffset(const Point2i &offset) = 0;
+
+    virtual void clear() = 0;
+
+    void mergeStats(VCMWorkResultBase* result) {
+        for (int i = 0; i < stats.size(); i++)
+            stats[i].accumulate(result->stats[i].value, result->stats[i].count);
+    }
+
+    std::vector<VCMStat> stats;
+protected:
+    std::vector<VCMPhoton> m_photonMap;
+};
+
+class VCMProcessBase : public BlockedRenderProcess {
+public:
+    using BlockedRenderProcess::BlockedRenderProcess;
+
+    void bindResource(const std::string &name, int id) {
+        BlockedRenderProcess::bindResource(name, id);
+        if (name == "sensor") {
+            if (!m_sensorPathPool.size()) {
+                nbx = ceil_div(m_film->getCropSize().x, m_blockSize);
+                nby = ceil_div(m_film->getCropSize().y, m_blockSize);
+                m_sensorPathPool.resize(nbx * nby);
+                m_emitterPathPool.resize(nbx * nby);
+            }
+        }
+    }
+
+    typedef nanoflann::KDTreeSingleIndexAdaptor<
+    nanoflann::L2_Simple_Adaptor<Float, VCMPhotonMap>,
+    VCMPhotonMap, 3 /* dim */ > kd_tree_t;
+
+    enum Phase {
+        SAMPLE, EVAL
+    } phase;
+    size_t nbx, nby; // number of blocks to render
+    std::vector<CompactBlockPathPool> m_sensorPathPool;
+    std::vector<CompactBlockPathPool> m_emitterPathPool;
+    VCMPhotonMap m_photonMap;
+    std::shared_ptr<kd_tree_t> m_photonKDTree;
+    Float m_mergeRadius;
+
+    void buildPhotonLookupStructure() {
+        m_photonKDTree.reset(new kd_tree_t(3, m_photonMap, nanoflann::KDTreeSingleIndexAdaptorParams()));
+        m_photonKDTree->buildIndex();
+    }
+
+    virtual void updateRadius(int n) {
+    }
+
+    void clearPhotons() {
+        m_photonMap.photons.clear();
+    }
+
+    std::vector<VCMPhoton> lookupPhotons(const PathVertex* vertex, float radius) {
+        std::vector<VCMPhoton> photons;
+        if (vertex->isDegenerate()) return photons;
+        const Point &position = vertex->getPosition();
+        std::vector<std::pair<size_t, Float> > indices_dists;
+        nanoflann::RadiusResultSet<Float> resultSet(radius*radius, indices_dists); // we square here because we used squared distance metric
+        m_photonKDTree->findNeighbors(resultSet, (Float*) & position, nanoflann::SearchParams());
+        for (const std::pair<size_t, Float>& index_dist : indices_dists) {
+            photons.push_back(m_photonMap.photons[index_dist.first]);
+        }
+        return photons;
+    }
+
+    void extractPhotonPath(const VCMPhoton& photon, Path& path, MemoryPool* pool = NULL, bool metropolis = false) {
+        if (!metropolis) {
+            if (!pool) {
+                m_emitterPathPool[photon.blockID].extractPathItem(path, photon.pointID);
+                return;
+            }
+            Path ep;
+            m_emitterPathPool[photon.blockID].extractPathItem(ep, photon.pointID);
+            ep.clone(path, *pool);
+        } else {
+            if (!pool) {
+                m_sensorPathPool[photon.blockID].extractPathItem(path, photon.pointID);
+                return;
+            }
+            Path sp;
+            m_sensorPathPool[photon.blockID].extractPathItem(sp, photon.pointID);
+            sp.clone(path, *pool);
+        }
+    }
+
+    void processResultSample(const VCMWorkResultBase *result) {
+        const std::vector<VCMPhoton>& photons = result->getPhotons();
+        m_photonMap.photons.insert(m_photonMap.photons.end(), photons.begin(), photons.end());
+    }
+};
+
+struct VCMConfigBase {
+    int maxDepth;
+    int rrDepth;
+    Float phExponent;
+    Float initialRadius;
+    bool mergeOnly;
+    bool metropolis;
+};
+
+class VCMRendererBase : public WorkProcessor {
+    using WorkProcessor::WorkProcessor;
+protected:
+
+    void extractPathPair(VCMProcessBase* process, Path& emitterSubpath, Path& sensorSubpath, const RectangularWorkUnit *rect, int pointID, bool clone = false) {
+        size_t blockSize = m_scene->getBlockSize();
+        size_t nbx = process->nbx;
+        size_t blockID = (rect->getOffset().y / blockSize) * nbx +
+                rect->getOffset().x / blockSize;
+        CompactBlockPathPool& sensorPathPool = process->m_sensorPathPool[blockID];
+        CompactBlockPathPool& emitterPathPool = process->m_emitterPathPool[blockID];
+
+        if (!clone) {
+            sensorPathPool.extractPathItem(sensorSubpath, pointID);
+            emitterPathPool.extractPathItem(emitterSubpath, pointID);
+            return;
+        }
+
+        Path s, e;
+        sensorPathPool.extractPathItem(s, pointID);
+        emitterPathPool.extractPathItem(e, pointID);
+        s.clone(sensorSubpath, m_pool);
+        e.clone(emitterSubpath, m_pool);
+    }
+
+    void processSampling(const WorkUnit *workUnit, WorkResult *workResult, const bool &stop, VCMProcessBase* m_process, VCMConfigBase* config) {
+        VCMConfigBase& m_config = *config;
+        const RectangularWorkUnit *rect = static_cast<const RectangularWorkUnit *> (workUnit);
+        VCMWorkResultBase *result = static_cast<VCMWorkResultBase *> (workResult);
+        bool needsTimeSample = m_sensor->needsTimeSample();
+        Float time = m_sensor->getShutterOpen();
+        size_t block_size = m_scene->getBlockSize();
+
+        result->setOffset(rect->getOffset());
+        result->setSize(rect->getSize());
+        result->clear();
+        m_hilbertCurve.initialize(TVector2<uint8_t>(rect->getSize()));
+
+        size_t nbx = m_process->nbx;
+        size_t blockID = (rect->getOffset().y / block_size) * nbx +
+                rect->getOffset().x / block_size;
+
+#if defined(MTS_DEBUG_FP)
+        enableFPExceptions();
+#endif
+
+        Path emitterSubpath;
+        Path sensorSubpath;
+
+        /* Determine the necessary random walk depths based on properties of
+           the endpoints */
+        int emitterDepth = m_config.maxDepth,
+                sensorDepth = m_config.maxDepth;
+
+        /* Go one extra step if the sensor can be intersected */
+        if (!m_scene->hasDegenerateSensor() && emitterDepth != -1)
+            ++emitterDepth;
+
+        /* Go one extra step if there are emitters that can be intersected */
+        if (!m_scene->hasDegenerateEmitters() && sensorDepth != -1)
+            ++sensorDepth;
+
+        CompactBlockPathPool& sensorPathPool = m_process->m_sensorPathPool[blockID];
+        CompactBlockPathPool& emitterPathPool = m_process->m_emitterPathPool[blockID];
+
+        sensorPathPool.clear();
+        emitterPathPool.clear();
+        result->clearPhotons();
+
+        for (size_t i = 0; i < m_hilbertCurve.getPointCount(); ++i) {
+            Point2i offset = Point2i(m_hilbertCurve[i]) + Vector2i(rect->getOffset());
+            m_sampler->generate(offset);
+            if (stop)
+                break;
+            if (needsTimeSample)
+                time = m_sensor->sampleTime(m_sampler->next1D());
+
+
+            if (m_config.metropolis) {
+                /* Perform two random walks from the sensor and emitter side */
+                sensorSubpath.initialize(m_scene, time, ERadiance, m_pool);
+                sensorSubpath.randomWalkFromPixel(m_scene, m_sampler, sensorDepth,
+                        offset, m_config.rrDepth, m_pool);
+
+                const Vector2i& image_size = m_sensor->getFilm()->getCropSize();
+                size_t nEmitterPaths = image_size.x * image_size.y;
+
+                Float radius = Path::estimateSensorMergingRadius(m_scene, emitterSubpath, sensorSubpath, 0, 2, nEmitterPaths,
+                        m_process->m_mergeRadius);
+
+                for (size_t k = 2; k < sensorSubpath.vertexCount(); k++) {
+                    if (k > 2) Path::adjustRadius(sensorSubpath.vertexOrNull(k - 1), radius, m_config.mergeOnly);
+
+                    if (radius == 0.f) break;
+
+                    PathVertex* vertex = sensorSubpath.vertex(k);
+                    if (!vertex->isSurfaceInteraction()) continue;
+                    if (vertex->isDegenerate()) continue;
+                    // add a new photon
+                    VCMPhoton photon;
+                    photon.pos = vertex->getPosition();
+                    photon.blockID = blockID;
+                    photon.pointID = i;
+                    photon.vertexID = k;
+                    photon.radius = radius;
+                    result->putPhoton(photon);
+                }
+
+                sensorPathPool.addPathItem(sensorSubpath); // cache path into sensor Path Pool
+                sensorSubpath.release(m_pool);
+            } else {
+                /* Start new emitter and sensor subpaths */
+                emitterSubpath.initialize(m_scene, time, EImportance, m_pool);
+                sensorSubpath.initialize(m_scene, time, ERadiance, m_pool);
+                /* Perform a random walk using alternating steps on each path */
+                Path::alternatingRandomWalkFromPixel(m_scene, m_sampler,
+                        emitterSubpath, emitterDepth, sensorSubpath,
+                        sensorDepth, offset, m_config.rrDepth, m_pool);
+
+                for (size_t k = 2; k < emitterSubpath.vertexCount(); k++) {
+                    PathVertex* vertex = emitterSubpath.vertex(k);
+                    if (!vertex->isSurfaceInteraction()) continue;
+                    if (vertex->isDegenerate()) continue;
+                    // add a new photon
+                    VCMPhoton photon;
+                    photon.pos = vertex->getPosition();
+                    photon.blockID = blockID;
+                    photon.pointID = i;
+                    photon.vertexID = k;
+                    result->putPhoton(photon);
+                }
+
+                sensorPathPool.addPathItem(sensorSubpath); // cache path into sensor Path Pool
+                emitterPathPool.addPathItem(emitterSubpath); // cache path into emitter Path Pool
+                emitterSubpath.release(m_pool);
+                sensorSubpath.release(m_pool);
+            }
+        }
+        sensorPathPool.buildIndex();
+        emitterPathPool.buildIndex();
+    }
+
+    ref<Scene> m_scene;
+    ref<Sensor> m_sensor;
+    ref<Sampler> m_sampler;
+    ref<PSSMLTSamplerBase> m_pssmltSampler;
+    HilbertCurve2D<uint8_t> m_hilbertCurve;
+    MemoryPool m_pool;
+};
+
+class VCMIntegratorBase : public Integrator {
+protected:
+    bool m_cancelled;
+    using Integrator::Integrator;
+public:
+
+    bool iterateVCM(VCMProcessBase* process, int sensorResID, int iter) {
+        ref<Scheduler> scheduler = Scheduler::getInstance();
+        process->updateRadius(iter + 1);
+        process->clearPhotons();
+        if (m_cancelled) return false;
+        // connection phase
+        // we also collect photons in this phase
+
+        process->bindResource("sensor", sensorResID);
+        process->phase = VCMProcessBase::SAMPLE;
+        scheduler->schedule(process);
+        scheduler->wait(process);
+        if (m_cancelled) return false;
+
+        // build photon look up structure
+        process->buildPhotonLookupStructure();
+
+        // merging phase
+        process->bindResource("sensor", sensorResID);
+        process->phase = VCMProcessBase::EVAL;
+        scheduler->schedule(process);
+        scheduler->wait(process);
+        if (m_cancelled) return false;
+        return true;
+    }
+};
+
+
+
+MTS_NAMESPACE_END
+
+#endif /* __VCM_PROC */

--- a/src/integrators/vcm/vcm_proc.cpp
+++ b/src/integrators/vcm/vcm_proc.cpp
@@ -715,6 +715,10 @@ void VCMProcess::bindResource(const std::string &name, int id) {
             m_result = new VCMWorkResult(m_config, NULL, m_film->getCropSize());
             m_result->clear();
         }
+        // The original progress calculator is wrong - VCM needs blocks * samples instead
+        if (m_progress)
+            delete m_progress;
+        m_progress = new ProgressReporter("Rendering", m_numBlocksTotal * m_config.sampleCount, m_parent);
     }
 }
 

--- a/src/integrators/vcm/vcm_proc.cpp
+++ b/src/integrators/vcm/vcm_proc.cpp
@@ -625,6 +625,8 @@ VCMProcess::VCMProcess(const RenderJob *parent, RenderQueue *queue,
 VCMProcessBase(parent, queue, config.blockSize), m_config(config) {
     m_refreshTimer = new Timer();
     m_weight = 1.f;
+    // Prevent the base class from initializing the progress bar
+    m_preserveProgress = true;
 }
 
 ref<WorkProcessor> VCMProcess::createWorkProcessor() const {
@@ -716,9 +718,8 @@ void VCMProcess::bindResource(const std::string &name, int id) {
             m_result->clear();
         }
         // The original progress calculator is wrong - VCM needs blocks * samples instead
-        if (m_progress)
-            delete m_progress;
-        m_progress = new ProgressReporter("Rendering", m_numBlocksTotal * m_config.sampleCount, m_parent);
+        if (!m_progress)
+          m_progress = new ProgressReporter("Rendering", m_numBlocksTotal * m_config.sampleCount, m_parent);
     }
 }
 

--- a/src/integrators/vcm/vcm_proc.cpp
+++ b/src/integrators/vcm/vcm_proc.cpp
@@ -1,0 +1,723 @@
+/*
+    This file is part of Mitsuba, a physically based rendering system.
+
+    Copyright (c) 2007-2014 by Wenzel Jakob and others.
+
+    Mitsuba is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License Version 3
+    as published by the Free Software Foundation.
+
+    Mitsuba is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <mitsuba/core/statistics.h>
+#include <mitsuba/core/sfcurve.h>
+#include <mitsuba/bidir/util.h>
+#include <mitsuba/bidir/pathsampler.h>
+#include <stdbool.h>
+#include <mitsuba/core/plugin.h>
+#include "vcm_proc.h"
+
+MTS_NAMESPACE_BEGIN
+
+#define D_EPSILON std::numeric_limits<Float>::min() // to avoid division by 0
+
+/* ==================================================================== */
+/*                         Worker implementation                        */
+/* ==================================================================== */
+
+class VCMRenderer : public VCMRendererBase {
+public:
+
+    VCMRenderer(const VCMConfiguration &config, VCMProcess* process) : m_config(config), m_process(process) {
+    }
+
+    VCMRenderer(const VCMConfiguration &config) : m_config(config) {
+    }
+
+    VCMRenderer(Stream *stream, InstanceManager *manager)
+    : VCMRendererBase(stream, manager), m_config(stream) {
+    }
+
+    virtual ~VCMRenderer() {
+    }
+
+    void serialize(Stream *stream, InstanceManager *manager) const {
+        m_config.serialize(stream);
+    }
+
+    ref<WorkUnit> createWorkUnit() const {
+        return new RectangularWorkUnit();
+    }
+
+    ref<WorkResult> createWorkResult() const {
+        return new VCMWorkResult(m_config, m_rfilter.get(),
+                Vector2i(m_config.blockSize));
+    }
+
+    void prepare() {
+        Scene *scene = static_cast<Scene *> (getResource("scene"));
+
+        m_scene = scene;
+        m_sampler = static_cast<Sampler *> (getResource("sampler"));
+        m_sensor = static_cast<Sensor *> (getResource("sensor"));
+        m_rfilter = m_sensor->getFilm()->getReconstructionFilter();
+
+        m_pssmltSampler = static_cast<PSSMLTSamplerBase *> (getResource("mltSampler"));
+        m_pssmltSampler->reset();
+        m_pssmltSampler->accept();
+
+        m_current.reset(new SplatList());
+        m_proposed.reset(new SplatList());
+        m_currentWeight = 0.f;
+        /*
+        m_scene = new Scene(scene);
+        m_scene->removeSensor(scene->getSensor());
+        m_scene->addSensor(m_sensor);
+        m_scene->setSensor(m_sensor);
+        m_scene->setSampler(m_sampler);
+        m_scene->wakeup(NULL, m_resources);
+        m_scene->initializeBidirectional();
+         */
+    }
+
+    void process(const WorkUnit *workUnit, WorkResult *workResult, const bool &stop) {
+        if (m_process->phase == VCMProcessBase::SAMPLE) {
+            processSampling(workUnit, workResult, stop, m_process, &m_config);
+            return;
+        }
+
+        const RectangularWorkUnit *rect = static_cast<const RectangularWorkUnit *> (workUnit);
+        VCMWorkResult *result = static_cast<VCMWorkResult *> (workResult);
+        bool needsTimeSample = m_sensor->needsTimeSample();
+        Float time = m_sensor->getShutterOpen();
+
+        result->setOffset(rect->getOffset());
+        result->setSize(rect->getSize());
+        result->clear();
+        m_hilbertCurve.initialize(TVector2<uint8_t>(rect->getSize()));
+
+#if defined(MTS_DEBUG_FP)
+        enableFPExceptions();
+#endif
+
+        Path emitterSubpath;
+        Path sensorSubpath;
+
+        /* Determine the necessary random walk depths based on properties of
+           the endpoints */
+        int emitterDepth = m_config.maxDepth,
+                sensorDepth = m_config.maxDepth;
+
+        /* Go one extra step if the sensor can be intersected */
+        if (!m_scene->hasDegenerateSensor() && emitterDepth != -1)
+            ++emitterDepth;
+
+        /* Go one extra step if there are emitters that can be intersected */
+        if (!m_scene->hasDegenerateEmitters() && sensorDepth != -1)
+            ++sensorDepth;
+
+
+
+        for (size_t i = 0; i < m_hilbertCurve.getPointCount(); ++i) {
+
+            if (stop)
+                break;
+
+            extractPathPair(m_process, emitterSubpath, sensorSubpath, rect, i); // extract cached paths from sampling phase
+
+            if (m_config.metropolis) {
+                bool large = m_pssmltSampler->getRandom()->nextFloat() < 0.3;
+                m_pssmltSampler->setLargeStep(large);
+
+                if (needsTimeSample)
+                    time = m_sensor->sampleTime(m_pssmltSampler->next1D());
+                emitterSubpath.initialize(m_scene, time, EImportance, m_pool);
+                emitterSubpath.randomWalk(m_scene, m_pssmltSampler, emitterDepth, m_config.rrDepth, EImportance, m_pool);
+                m_proposed->clear();
+                m_proposedWeight = 0.f;
+            }
+
+            Point2 initialSamplePos = sensorSubpath.vertex(1)->getSamplePosition();
+            Spectrum color(Float(0.f));
+            if (!m_config.mergeOnly) color += evaluateConnection(result, emitterSubpath, sensorSubpath);
+
+            color += evaluateMerging(result, emitterSubpath, sensorSubpath);
+            result->putSample(initialSamplePos, color, 1.f);
+
+            if (m_config.metropolis) {
+                auto target_func_vis = [&]() {
+                    m_proposedWeight = m_proposed->size() > 0 ? 1.f : 0.f;
+                };
+
+                target_func_vis();
+
+                if (m_pssmltSampler->isLargeStep()) {
+                    result->stats[0].accumulate(m_proposedWeight, 1); // total normalization
+                }
+
+                if (result->stats[1].count >= 10) {
+                    Float acc_rate = result->stats[1].value;
+                    Float strength = m_pssmltSampler->getStrength();
+                    strength = strength + (acc_rate - 0.234f) / result->stats[1].count;
+                    strength = std::min(Float(5.f), std::max(Float(1e-4f), strength));
+                    m_pssmltSampler->updateStrength(strength);
+                }
+
+                bool acc = m_proposedWeight > 0.f;
+                if (m_proposedWeight < m_currentWeight)
+                    acc = m_pssmltSampler->getRandom()->nextFloat() < m_proposedWeight / m_currentWeight;
+
+                if (acc) {
+                    m_pssmltSampler->accept();
+                    m_current.swap(m_proposed);
+                    m_currentWeight = m_proposedWeight;
+                    result->stats[1].accumulate(1.0, 1); // acceptance rate
+                } else {
+                    m_pssmltSampler->reject();
+                    result->stats[1].accumulate(0.0, 1);
+                }
+                emitterSubpath.release(m_pool);
+
+                // render current splats
+                if (m_currentWeight > 0.f) {
+                    for (int i = 0; i < m_current->size(); i++)
+                        result->putLightSample(m_current->getPosition(i), m_current->getValue(i) / m_currentWeight);
+                }
+            }
+
+        }
+
+#if defined(MTS_DEBUG_FP)
+        disableFPExceptions();
+#endif
+
+        /* Make sure that there were no memory leaks */
+        Assert(m_pool.unused());
+    }
+
+    /// Evaluate the contributions of the given eye and light paths
+
+    Spectrum evaluateConnection(VCMWorkResult *wr,
+            Path &emitterSubpath, Path &sensorSubpath, bool reconnect = false) {
+        Point2 initialSamplePos = sensorSubpath.vertex(1)->getSamplePosition();
+        const Scene *scene = m_scene;
+        PathVertex tempEndpoint, tempSample;
+        PathEdge tempEdge, connectionEdge;
+
+        /* Compute the combined weights along the two subpaths */
+        Spectrum *importanceWeights = (Spectrum *) alloca(emitterSubpath.vertexCount() * sizeof (Spectrum)),
+                *radianceWeights = (Spectrum *) alloca(sensorSubpath.vertexCount() * sizeof (Spectrum));
+
+        importanceWeights[0] = radianceWeights[0] = Spectrum(1.0f);
+        for (size_t i = 1; i < emitterSubpath.vertexCount(); ++i)
+            importanceWeights[i] = importanceWeights[i - 1] *
+                emitterSubpath.vertex(i - 1)->weight[EImportance] *
+                emitterSubpath.vertex(i - 1)->rrWeight *
+                emitterSubpath.edge(i - 1)->weight[EImportance];
+
+        for (size_t i = 1; i < sensorSubpath.vertexCount(); ++i)
+            radianceWeights[i] = radianceWeights[i - 1] *
+                sensorSubpath.vertex(i - 1)->weight[ERadiance] *
+                sensorSubpath.vertex(i - 1)->rrWeight *
+                sensorSubpath.edge(i - 1)->weight[ERadiance];
+
+        Spectrum sampleValue(0.0f);
+        for (int s = (int) emitterSubpath.vertexCount() - 1; s >= 0; --s) {
+            /* Determine the range of sensor vertices to be traversed,
+               while respecting the specified maximum path length */
+            int minT = std::max(2 - s, m_config.lightImage ? 0 : 2),
+                    maxT = (int) sensorSubpath.vertexCount() - 1;
+            if (m_config.maxDepth != -1)
+                maxT = std::min(maxT, m_config.maxDepth + 1 - s);
+            for (int t = maxT; t >= minT; --t) {
+
+                PathVertex
+                        *vsPred = emitterSubpath.vertexOrNull(s - 1),
+                        *vtPred = sensorSubpath.vertexOrNull(t - 1),
+                        *vs = emitterSubpath.vertex(s),
+                        *vt = sensorSubpath.vertex(t);
+                PathEdge
+                        *vsEdge = emitterSubpath.edgeOrNull(s - 1),
+                        *vtEdge = sensorSubpath.edgeOrNull(t - 1);
+
+                RestoreMeasureHelper rmh0(vs), rmh1(vt);
+
+                /* Will be set to true if direct sampling was used */
+                bool sampleDirect = false;
+
+                /* Stores the pixel position associated with this sample */
+                Point2 samplePos = initialSamplePos;
+
+                /* Allowed remaining number of ENull vertices that can
+                   be bridged via pathConnect (negative=arbitrarily many) */
+                int remaining = m_config.maxDepth - s - t + 1;
+
+                /* Will receive the path weight of the (s, t)-connection */
+                Spectrum value;
+
+                /* Account for the terms of the measurement contribution
+                   function that are coupled to the connection endpoints */
+                if (vs->isEmitterSupernode()) {
+                    /* If possible, convert 'vt' into an emitter sample */
+                    if (!vt->cast(scene, PathVertex::EEmitterSample) || vt->isDegenerate())
+                        continue;
+
+                    value = radianceWeights[t] *
+                            vs->eval(scene, vsPred, vt, EImportance) *
+                            vt->eval(scene, vtPred, vs, ERadiance);
+                } else if (vt->isSensorSupernode()) {
+                    /* If possible, convert 'vs' into an sensor sample */
+                    if (!vs->cast(scene, PathVertex::ESensorSample) || vs->isDegenerate())
+                        continue;
+
+                    /* Make note of the changed pixel sample position */
+                    if (!vs->getSamplePosition(vsPred, samplePos))
+                        continue;
+
+                    value = importanceWeights[s] *
+                            vs->eval(scene, vsPred, vt, EImportance) *
+                            vt->eval(scene, vtPred, vs, ERadiance);
+                } else if (m_config.sampleDirect && ((t == 1 && s > 1) || (s == 1 && t > 1))) {
+                    /* s==1/t==1 path: use a direct sampling strategy if requested */
+                    if (s == 1) {
+                        if (vt->isDegenerate())
+                            continue;
+                        /* Generate a position on an emitter using direct sampling */
+                        value = radianceWeights[t] * vt->sampleDirect(scene, m_sampler,
+                                &tempEndpoint, &tempEdge, &tempSample, EImportance);
+                        if (value.isZero())
+                            continue;
+                        vs = &tempSample;
+                        vsPred = &tempEndpoint;
+                        vsEdge = &tempEdge;
+                        value *= vt->eval(scene, vtPred, vs, ERadiance);
+                        vt->measure = EArea;
+                    } else {
+                        if (vs->isDegenerate())
+                            continue;
+                        /* Generate a position on the sensor using direct sampling */
+                        value = importanceWeights[s] * vs->sampleDirect(scene, m_sampler,
+                                &tempEndpoint, &tempEdge, &tempSample, ERadiance);
+                        if (value.isZero())
+                            continue;
+                        vt = &tempSample;
+                        vtPred = &tempEndpoint;
+                        vtEdge = &tempEdge;
+                        value *= vs->eval(scene, vsPred, vt, EImportance);
+                        vs->measure = EArea;
+                    }
+
+                    sampleDirect = true;
+                } else {
+                    /* Can't connect degenerate endpoints */
+                    if (vt->isDegenerate() || vs->isDegenerate()) continue;
+
+                    value = importanceWeights[s] * radianceWeights[t] *
+                            vs->eval(scene, vsPred, vt, EImportance) *
+                            vt->eval(scene, vtPred, vs, ERadiance);
+
+                    /* Temporarily force vertex measure to EArea. Needed to
+                       handle BSDFs with diffuse + specular components */
+                    vs->measure = vt->measure = EArea;
+                }
+
+
+                const Vector2i& image_size = m_sensor->getFilm()->getCropSize();
+                size_t nEmitterPaths = image_size.x * image_size.y;
+                /* Compute the multiple importance sampling weight */
+
+
+                /* Attempt to connect the two endpoints, which could result in
+                   the creation of additional vertices (index-matched boundaries etc.) */
+                int interactions = remaining; // backup
+                if (value.isZero() || !connectionEdge.pathConnectAndCollapse(
+                        scene, vsEdge, vs, vt, vtEdge, interactions))
+                    continue;
+
+                /* Account for the terms of the measurement contribution
+                   function that are coupled to the connection edge */
+                if (!sampleDirect)
+                    value *= connectionEdge.evalCached(vs, vt, PathEdge::EGeneralizedGeometricTerm);
+                else
+                    value *= connectionEdge.evalCached(vs, vt, PathEdge::ETransmittance |
+                        (s == 1 ? PathEdge::ECosineRad : PathEdge::ECosineImp));
+
+
+
+                if (sampleDirect) {
+                    /* A direct sampling strategy was used, which generated
+                       two new vertices at one of the path ends. Temporarily
+                       modify the path to reflect this change */
+                    if (t == 1)
+                        sensorSubpath.swapEndpoints(vtPred, vtEdge, vt);
+                    else
+                        emitterSubpath.swapEndpoints(vsPred, vsEdge, vs);
+                }
+
+
+
+                Float miWeight = Path::miWeightVCM(scene, emitterSubpath, &connectionEdge,
+                        sensorSubpath, s, t, m_config.sampleDirect, m_config.lightImage, m_config.phExponent,
+                        m_process->m_mergeRadius, nEmitterPaths, false, m_config.mergeOnly);
+
+
+                if (sampleDirect) {
+                    /* Now undo the previous change */
+                    if (t == 1)
+                        sensorSubpath.swapEndpoints(vtPred, vtEdge, vt);
+                    else
+                        emitterSubpath.swapEndpoints(vsPred, vsEdge, vs);
+                }
+
+                /* Determine the pixel sample position when necessary */
+                if (vt->isSensorSample() && !vt->getSamplePosition(vs, samplePos))
+                    continue;
+
+#if VCM_DEBUG == 1
+                /* When the debug mode is on, collect samples
+                   separately for each sampling strategy. Note: the
+                   following piece of code artificially increases the
+                   exposure of longer paths */
+                Spectrum splatValue = value * (m_config.showWeighted
+                        ? miWeight : 1.0f); // * std::pow(2.0f, s+t-3.0f));
+                wr->putDebugSample(s, t, samplePos, splatValue);
+#endif
+                if (t >= 2)
+                    sampleValue += value * miWeight;
+                else
+                    wr->putLightSample(samplePos, value * miWeight);
+            }
+        }
+        return sampleValue;
+    }
+
+    Spectrum evaluateMerging(VCMWorkResult *wr, Path& emitterSubpath, Path &sensorSubpath) {
+
+        const Scene *scene = m_scene;
+        PathEdge connectionEdge;
+        Spectrum sampleValue(0.0f);
+
+        const Vector2i& image_size = m_sensor->getFilm()->getCropSize();
+        size_t nEmitterPaths = image_size.x * image_size.y;
+
+        Float radius = Path::estimateSensorMergingRadius(scene, emitterSubpath, sensorSubpath, 0, 2, nEmitterPaths,
+                m_process->m_mergeRadius);
+
+        auto merge = [&](const Path& emitterSubpath, const Path& sensorSubpath, int s, int t, const Spectrum& wsp1, const Spectrum & wt) {
+            Point2 initialSamplePos = sensorSubpath.vertex(1)->getSamplePosition();
+            PathVertex *vt = sensorSubpath.vertex(t); // the vertex we are looking at
+            PathVertex
+                    *vsPred = emitterSubpath.vertexOrNull(s - 1),
+                    *vtPred = sensorSubpath.vertexOrNull(t - 1),
+                    *vs = emitterSubpath.vertex(s);
+
+            PathEdge
+                    *vsEdge = emitterSubpath.edgeOrNull(s - 1),
+                    *vtEdge = sensorSubpath.edgeOrNull(t - 1);
+
+            PathVertex *vt_photon = emitterSubpath.vertex(s + 1);
+
+
+            // Discard photons whose normals are way off.
+            Vector d = normalize(vt->getPosition() - vs->getPosition());
+            Vector photonN = vt_photon->getGeometricNormal();
+            Vector centerN = vt->getGeometricNormal();
+            Float N_ = absDot(photonN, d);
+            if ((dot(photonN, centerN) < 1e-1f) || (N_ < 1e-2f)) return;
+
+            Float p_acc = emitterSubpath.vertex(s)->pdf[EImportance] * M_PI * radius * radius;
+            p_acc = std::min(Float(1.f), p_acc); // acceptance probability
+
+
+
+            RestoreMeasureHelper rmh0(vs), rmh1(vt);
+
+            /* Will be set to true if direct sampling was used */
+            bool sampleDirect = false;
+
+            /* Stores the pixel position associated with this sample */
+            Point2 samplePos = initialSamplePos;
+
+            /* Allowed remaining number of ENull vertices that can
+               be bridged via pathConnect (negative=arbitrarily many) */
+            int remaining = m_config.maxDepth - s - t + 1;
+
+            /* Will receive the path weight of the (s, t)-connection */
+            Spectrum value;
+
+            /* Account for the terms of the measurement contribution
+               function that are coupled to the connection endpoints */
+
+
+            p_acc = 1.0;
+            value = wsp1 * wt *
+                    vt->eval(scene, vtPred, vs, ERadiance) / (M_PI * radius * radius);
+            /* Temporarily force vertex measure to EArea. Needed to
+            handle BSDFs with diffuse + specular components */
+            vt->measure = EArea;
+
+            /* Attempt to connect the two endpoints, which could result in
+               the creation of additional vertices (index-matched boundaries etc.) */
+            int interactions = remaining; // backup
+
+
+            if (value.isZero() || !connectionEdge.pathConnectAndCollapse(
+                    scene, vsEdge, vs, vt, vtEdge, interactions, true))
+                return;
+
+            /* Account for the terms of the measurement contribution
+               function that are coupled to the connection edge */
+
+            /* Compute the multiple importance sampling weight */
+
+            Float miWeight = Path::miWeightVCM(scene, emitterSubpath, &connectionEdge,
+                    sensorSubpath, s, t, false, m_config.lightImage, m_config.phExponent,
+                    m_process->m_mergeRadius, nEmitterPaths, true, m_config.mergeOnly);
+
+            /* Determine the pixel sample position when necessary */
+            if (vt->isSensorSample() && !vt->getSamplePosition(vs, samplePos))
+                return;
+
+#if VCM_DEBUG == 1
+            /* When the debug mode is on, collect samples
+               separately for each sampling strategy. Note: the
+               following piece of code artificially increases the
+               exposure of longer paths */
+            Spectrum splatValue = value * (m_config.showWeighted
+                    ? miWeight : 1.0f); // * std::pow(2.0f, s+t-3.0f));
+            wr->putDebugSample(s, t, samplePos, splatValue);
+#endif
+            Spectrum inc = value * Spectrum(miWeight) / p_acc;
+            Float normal_correction_factor = absDot(vt_photon->getShadingNormal(), d) /
+                    (D_EPSILON + absDot(vt_photon->getGeometricNormal(), d));
+            inc *= normal_correction_factor;
+            if (inc.hasNan())
+                return;
+            if (m_config.metropolis)
+                m_proposed->append(samplePos, inc);
+            else
+                sampleValue += inc;
+        };
+
+        if (!m_config.metropolis) { // query photons
+            Path emitterSubpath; // overwrite argument
+            Spectrum *radianceWeights = (Spectrum *) alloca(sensorSubpath.vertexCount() * sizeof (Spectrum));
+            radianceWeights[0] = Spectrum(1.0f);
+            for (size_t i = 1; i < sensorSubpath.vertexCount(); ++i)
+                radianceWeights[i] = radianceWeights[i - 1] *
+                    sensorSubpath.vertex(i - 1)->weight[ERadiance] *
+                    sensorSubpath.vertex(i - 1)->rrWeight *
+                    sensorSubpath.edge(i - 1)->weight[ERadiance];
+
+            int minT = 2;
+            int maxT = (int) sensorSubpath.vertexCount() - 1;
+            if (m_config.maxDepth != -1)
+                maxT = std::min(maxT, m_config.maxDepth + 1);
+            for (int t = minT; t <= maxT; ++t) {
+                PathVertex *vt = sensorSubpath.vertex(t); // the vertex we are looking at
+
+                if (radius == 0.0) break;
+
+                if (vt->isDegenerate()) continue;
+
+                // look up photons
+                std::vector<VCMPhoton> photons = m_process->lookupPhotons(vt, radius);
+
+                for (const VCMPhoton& photon : photons) { // inspect every photon in range
+                    int s = photon.vertexID - 1; // pretend that a connection can be formed from the previous vertex.
+                    if (m_config.maxDepth > -1 && s + t > m_config.maxDepth + 1) continue;
+                    m_process->extractPhotonPath(photon, emitterSubpath); // extract the path that this photon bounded to.
+
+                    /* Compute the combined weights along the two subpaths */
+
+                    Spectrum wsp1 = Spectrum(1.f);
+
+                    for (size_t i = 1; i <= s + 1; ++i)
+                        wsp1 *= emitterSubpath.vertex(i - 1)->weight[EImportance] *
+                            emitterSubpath.vertex(i - 1)->rrWeight *
+                            emitterSubpath.edge(i - 1)->weight[EImportance];
+
+                    merge(emitterSubpath, sensorSubpath, s, t, wsp1, radianceWeights[t]);
+                }
+            }
+        } else { // query importons
+            Path sensorSubpath;
+            Spectrum *importanceWeights = (Spectrum *) alloca(emitterSubpath.vertexCount() * sizeof (Spectrum));
+            importanceWeights[0] = Spectrum(1.0f);
+            for (size_t i = 1; i < emitterSubpath.vertexCount(); ++i)
+                importanceWeights[i] = importanceWeights[i - 1] *
+                    emitterSubpath.vertex(i - 1)->weight[EImportance] *
+                    emitterSubpath.vertex(i - 1)->rrWeight *
+                    emitterSubpath.edge(i - 1)->weight[EImportance];
+
+            int minS = 1;
+            int maxS = (int) emitterSubpath.vertexCount() - 2;
+            if (m_config.maxDepth != -1)
+                maxS = std::min(maxS, m_config.maxDepth);
+
+            for (int s = minS; s <= maxS; ++s) {
+                PathVertex *vsp1 = emitterSubpath.vertex(s + 1); // the vertex we are looking at
+                if (vsp1->isDegenerate()) continue;
+
+                // look up photons
+                std::vector<VCMPhoton> photons = m_process->lookupPhotons(vsp1, radius);
+
+                for (const VCMPhoton& photon : photons) { // inspect every photon in range
+                    Float dist = (photon.pos - vsp1->getPosition()).length();
+                    if (dist > photon.radius) continue;
+
+                    int t = photon.vertexID; // pretend that a connection can be formed from the previous vertex.
+                    if (m_config.maxDepth > -1 && s + t > m_config.maxDepth + 1) continue;
+
+                    m_process->extractPhotonPath(photon, sensorSubpath, NULL, true); // extract the path that this photon bounded to.
+                    /* Compute the combined weights along the two subpaths */
+
+                    Spectrum wt = Spectrum(1.f);
+
+                    for (size_t i = 1; i <= t; ++i)
+                        wt *= sensorSubpath.vertex(i - 1)->weight[ERadiance] *
+                            sensorSubpath.vertex(i - 1)->rrWeight *
+                            sensorSubpath.edge(i - 1)->weight[ERadiance];
+
+                    merge(emitterSubpath, sensorSubpath, s, t, importanceWeights[s + 1], wt);
+                }
+            }
+        }
+
+        return sampleValue;
+    }
+
+    ref<WorkProcessor> clone() const {
+        return new VCMRenderer(m_config);
+    }
+
+    MTS_DECLARE_CLASS()
+private:
+
+    ref<ReconstructionFilter> m_rfilter;
+
+    VCMConfiguration m_config;
+
+    VCMProcess* m_process;
+
+    Float m_currentWeight, m_proposedWeight;
+
+    std::shared_ptr<SplatList> m_current, m_proposed;
+
+
+};
+
+
+/* ==================================================================== */
+/*                           Parallel process                           */
+
+/* ==================================================================== */
+
+VCMProcess::VCMProcess(const RenderJob *parent, RenderQueue *queue,
+        const VCMConfiguration &config) :
+VCMProcessBase(parent, queue, config.blockSize), m_config(config) {
+    m_refreshTimer = new Timer();
+    m_weight = 1.f;
+}
+
+ref<WorkProcessor> VCMProcess::createWorkProcessor() const {
+    VCMProcess* proc = const_cast<VCMProcess*> (this);
+    return new VCMRenderer(m_config, proc);
+}
+
+void VCMProcess::develop() {
+    if (!m_config.lightImage)
+        return;
+    LockGuard lock(m_resultMutex);
+    const ImageBlock *lightImage = m_result->getLightImage();
+    m_film->setBitmap(m_result->getImageBlock()->getBitmap());
+    m_film->addBitmap(lightImage->getBitmap(), 1.0f / m_config.sampleCount * m_weight);
+    m_refreshTimer->reset();
+    m_queue->signalRefresh(m_parent);
+}
+
+void VCMProcess::processResult(const WorkResult *wr, bool cancelled) {
+    if (cancelled)
+        return;
+    const VCMWorkResult *result = static_cast<const VCMWorkResult *> (wr);
+    ImageBlock *block = const_cast<ImageBlock *> (result->getImageBlock());
+    LockGuard lock(m_resultMutex);
+
+    if (m_config.metropolis) {
+        m_result->mergeStats((VCMWorkResultBase*) result);
+        m_weight = m_result->stats[0].value;
+    }
+
+    if (phase == SAMPLE) {
+        processResultSample(result);
+        m_queue->signalWorkEnd(m_parent, result->getImageBlock(), false);
+        return;
+    }
+    m_progress->update(++m_resultCount);
+    if (m_config.lightImage) {
+        const ImageBlock *lightImage = m_result->getLightImage();
+        m_result->put(result);
+        if (m_parent->isInteractive()) {
+            /* Modify the finished image block so that it includes the light image contributions,
+               which creates a more intuitive preview of the rendering process. This is
+               not 100% correct but doesn't matter, as the shown image will be properly re-developed
+               every 2 seconds and once more when the rendering process finishes */
+
+            Float invSampleCount = 1.0f / m_config.sampleCount;
+            const Bitmap *sourceBitmap = lightImage->getBitmap();
+            Bitmap *destBitmap = block->getBitmap();
+            int borderSize = block->getBorderSize();
+            Point2i offset = block->getOffset();
+            Vector2i size = block->getSize();
+
+            for (int y = 0; y < size.y; ++y) {
+                const Float *source = sourceBitmap->getFloatData()
+                        + (offset.x + (y + offset.y) * sourceBitmap->getWidth()) * SPECTRUM_SAMPLES;
+                Float *dest = destBitmap->getFloatData()
+                        + (borderSize + (y + borderSize) * destBitmap->getWidth()) * (SPECTRUM_SAMPLES + 2);
+
+                for (int x = 0; x < size.x; ++x) {
+                    Float weight = dest[SPECTRUM_SAMPLES + 1] * invSampleCount * m_weight;
+                    for (int k = 0; k < SPECTRUM_SAMPLES; ++k)
+                        *dest++ += *source++ * weight;
+                    dest += 2;
+                }
+            }
+        }
+    }
+
+    m_film->put(block);
+
+    /* Re-develop the entire image every two seconds if partial results are
+       visible (e.g. in a graphical user interface). This only applies when
+       there is a light image. */
+    bool developFilm = m_config.lightImage &&
+            (m_parent->isInteractive() && m_refreshTimer->getMilliseconds() > 2000);
+
+    m_queue->signalWorkEnd(m_parent, result->getImageBlock(), false);
+
+    if (developFilm)
+        develop();
+}
+
+void VCMProcess::bindResource(const std::string &name, int id) {
+    VCMProcessBase::bindResource(name, id);
+    if (name == "sensor") {
+        if (!m_result.get()) {
+            /* If needed, allocate memory for the light image */
+            m_result = new VCMWorkResult(m_config, NULL, m_film->getCropSize());
+            m_result->clear();
+        }
+    }
+}
+
+MTS_IMPLEMENT_CLASS_S(VCMRenderer, false, WorkProcessor)
+MTS_IMPLEMENT_CLASS(VCMProcess, false, BlockedRenderProcess)
+MTS_NAMESPACE_END

--- a/src/integrators/vcm/vcm_proc.h
+++ b/src/integrators/vcm/vcm_proc.h
@@ -1,0 +1,77 @@
+/*
+    This file is part of Mitsuba, a physically based rendering system.
+
+    Copyright (c) 2007-2014 by Wenzel Jakob and others.
+
+    Mitsuba is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License Version 3
+    as published by the Free Software Foundation.
+
+    Mitsuba is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if !defined(__VCM_PROC_H)
+#define __VCM_PROC_H
+
+#include <mitsuba/render/renderproc.h>
+#include <mitsuba/render/renderjob.h>
+#include <mitsuba/core/bitmap.h>
+#include "vcm_wr.h"
+
+
+
+#if defined(MTS_OPENMP)
+#define NANOFLANN_USE_OMP
+#endif
+#include <mitsuba/core/nanoflann.h>
+
+MTS_NAMESPACE_BEGIN
+
+/* ==================================================================== */
+/*                           Parallel process                           */
+/* ==================================================================== */
+
+class VCMProcess : public VCMProcessBase
+{
+    friend class VCMRenderer;
+public:
+    VCMProcess(const RenderJob *parent, RenderQueue *queue,
+            const VCMConfiguration &config);
+
+    inline const VCMWorkResult *getResult() const
+    {
+        return m_result.get();
+    }
+
+    /// Develop the image
+    void develop();
+    
+    void updateRadius(int n) {
+        m_mergeRadius = m_config.initialRadius / pow(n, 1.0 - m_config.radiusReductionAlpha);
+    }
+
+    /* ParallelProcess impl. */
+    void processResult(const WorkResult *wr, bool cancelled);
+    ref<WorkProcessor> createWorkProcessor() const;
+    void bindResource(const std::string &name, int id);
+
+    MTS_DECLARE_CLASS()
+protected:
+    /// Virtual destructor
+    virtual ~VCMProcess() {}
+private:
+    ref<VCMWorkResult> m_result;
+    ref<Timer> m_refreshTimer;
+    VCMConfiguration m_config;
+    Float m_weight;
+};
+
+MTS_NAMESPACE_END
+
+#endif /* __VCM_PROC */

--- a/src/integrators/vcm/vcm_wr.cpp
+++ b/src/integrators/vcm/vcm_wr.cpp
@@ -1,0 +1,138 @@
+/*
+    This file is part of Mitsuba, a physically based rendering system.
+
+    Copyright (c) 2007-2014 by Wenzel Jakob and others.
+
+    Mitsuba is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License Version 3
+    as published by the Free Software Foundation.
+
+    Mitsuba is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <mitsuba/core/bitmap.h>
+#include <mitsuba/core/fstream.h>
+#include "vcm_wr.h"
+#include "mitsuba/bidir/path.h"
+
+MTS_NAMESPACE_BEGIN
+
+/* ==================================================================== */
+/*                             Work result                              */
+/* ==================================================================== */
+
+VCMWorkResult::VCMWorkResult(const VCMConfiguration &conf,
+        const ReconstructionFilter *rfilter, Vector2i blockSize) {
+    stats.resize(2);
+    /* Stores the 'camera image' -- this can be blocked when
+       spreading out work to multiple workers */
+    if (blockSize == Vector2i(-1, -1))
+        blockSize = Vector2i(conf.blockSize, conf.blockSize);
+
+    m_block = new ImageBlock(Bitmap::ESpectrumAlphaWeight, blockSize, rfilter);
+    m_block->setOffset(Point2i(0, 0));
+    m_block->setSize(blockSize);
+
+    if (conf.lightImage) {
+        /* Stores the 'light image' -- every worker requires a
+           full-resolution version, since contributions of s==0
+           and s==1 paths can affect any pixel of this bitmap */
+        m_lightImage = new ImageBlock(Bitmap::ESpectrum,
+                conf.cropSize, rfilter);
+        m_lightImage->setSize(conf.cropSize);
+        m_lightImage->setOffset(Point2i(0, 0));
+    }
+
+    /* When debug mode is active, we additionally create
+       full-resolution bitmaps storing the contributions of
+       each individual sampling strategy */
+#if VCM_DEBUG == 1
+    m_debugBlocks.resize(
+            conf.maxDepth * (5 + conf.maxDepth) / 2);
+
+    for (size_t i = 0; i < m_debugBlocks.size(); ++i) {
+        m_debugBlocks[i] = new ImageBlock(
+                Bitmap::ESpectrum, conf.cropSize, rfilter);
+        m_debugBlocks[i]->setOffset(Point2i(0, 0));
+        m_debugBlocks[i]->setSize(conf.cropSize);
+    }
+#endif
+}
+
+VCMWorkResult::~VCMWorkResult() {
+}
+
+void VCMWorkResult::put(const VCMWorkResult *workResult) {
+#if VCM_DEBUG == 1
+    for (size_t i = 0; i < m_debugBlocks.size(); ++i)
+        m_debugBlocks[i]->put(workResult->m_debugBlocks[i].get());
+#endif
+    m_block->put(workResult->m_block.get());
+    if (m_lightImage)
+        m_lightImage->put(workResult->m_lightImage.get());
+}
+
+void VCMWorkResult::clear() {
+#if VCM_DEBUG == 1
+    for (size_t i = 0; i < m_debugBlocks.size(); ++i)
+        m_debugBlocks[i]->clear();
+#endif
+    if (m_lightImage)
+        m_lightImage->clear();
+    m_block->clear();
+}
+
+#if VCM_DEBUG == 1
+
+/* In debug mode, this function allows to dump the contributions of
+   the individual sampling strategies to a series of images */
+void VCMWorkResult::dump(const VCMConfiguration &conf,
+        const fs::path &prefix, const fs::path &stem) const {
+    Float weight = (Float) 1.0f / (Float) conf.sampleCount;
+    for (int k = 1; k <= conf.maxDepth; ++k) {
+        for (int t = 0; t <= k + 1; ++t) {
+            size_t s = k + 1 - t;
+            Bitmap *bitmap = const_cast<Bitmap *> (m_debugBlocks[strategyIndex(s, t)]->getBitmap());
+            ref<Bitmap> ldrBitmap = bitmap->convert(Bitmap::ERGB, Bitmap::EUInt8, -1, weight);
+            fs::path filename =
+                    prefix / fs::path(formatString("%s_k%02i_s%02i_t%02i.png", stem.filename().string().c_str(), k, s, t));
+            ref<FileStream> targetFile = new FileStream(filename,
+                    FileStream::ETruncReadWrite);
+            ldrBitmap->write(Bitmap::EPNG, targetFile, 1);
+        }
+    }
+}
+#endif
+
+void VCMWorkResult::load(Stream *stream) {
+#if VCM_DEBUG == 1
+    for (size_t i = 0; i < m_debugBlocks.size(); ++i)
+        m_debugBlocks[i]->load(stream);
+#endif
+    if (m_lightImage)
+        m_lightImage->load(stream);
+    m_block->load(stream);
+}
+
+void VCMWorkResult::save(Stream *stream) const {
+#if VCM_DEBUG == 1
+    for (size_t i = 0; i < m_debugBlocks.size(); ++i)
+        m_debugBlocks[i]->save(stream);
+#endif
+    if (m_lightImage.get())
+        m_lightImage->save(stream);
+    m_block->save(stream);
+}
+
+std::string VCMWorkResult::toString() const {
+    return m_block->toString();
+}
+
+MTS_IMPLEMENT_CLASS(VCMWorkResult, false, WorkResult)
+MTS_NAMESPACE_END

--- a/src/integrators/vcm/vcm_wr.h
+++ b/src/integrators/vcm/vcm_wr.h
@@ -1,0 +1,117 @@
+/*
+    This file is part of Mitsuba, a physically based rendering system.
+
+    Copyright (c) 2007-2014 by Wenzel Jakob and others.
+
+    Mitsuba is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License Version 3
+    as published by the Free Software Foundation.
+
+    Mitsuba is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#if !defined(__VCM_WR_H)
+#define __VCM_WR_H
+
+#include <mitsuba/render/imageblock.h>
+#include <mitsuba/core/fresolver.h>
+#include <mitsuba/bidir/util.h>
+#include "vcm.h"
+#include "vcm_basics.h"
+
+MTS_NAMESPACE_BEGIN
+
+/* ==================================================================== */
+/*                             Work result                              */
+/* ==================================================================== */
+
+/**
+   Bidirectional path tracing needs its own WorkResult implementation,
+   since each rendering thread simultaneously renders to a small 'camera
+   image' block and potentially a full-resolution 'light image'.
+ */
+
+class VCMWorkResult : public VCMWorkResultBase {
+public:
+    VCMWorkResult(const VCMConfiguration &conf, const ReconstructionFilter *filter,
+            Vector2i blockSize = Vector2i(-1, -1));
+
+    // Clear the contents of the work result
+    void clear();
+
+    /// Fill the work result with content acquired from a binary data stream
+    virtual void load(Stream *stream);
+
+    /// Serialize a work result to a binary data stream
+    virtual void save(Stream *stream) const;
+
+    /// Aaccumulate another work result into this one
+    void put(const VCMWorkResult *workResult);
+
+#if VCM_DEBUG == 1
+    /* In debug mode, this function allows to dump the contributions of
+       the individual sampling strategies to a series of images */
+    void dump(const VCMConfiguration &conf,
+            const fs::path &prefix, const fs::path &stem) const;
+
+    inline void putDebugSample(int s, int t, const Point2 &sample,
+            const Spectrum &spec) {
+        m_debugBlocks[strategyIndex(s, t)]->put(sample, (const Float *) &spec);
+    }
+#endif
+
+    inline void putSample(const Point2 &sample, const Spectrum &spec, Float weight = 1.f) {
+        m_block->put(sample, spec, weight);
+    }
+
+    inline void putLightSample(const Point2 &sample, const Spectrum &spec) {
+        m_lightImage->put(sample, spec, 1.0f);
+    }
+
+    inline const ImageBlock *getImageBlock() const {
+        return m_block.get();
+    }
+
+    inline const ImageBlock *getLightImage() const {
+        return m_lightImage.get();
+    }
+
+    inline void setSize(const Vector2i &size) {
+        m_block->setSize(size);
+    }
+
+    inline void setOffset(const Point2i &offset) {
+        m_block->setOffset(offset);
+    }
+    
+    
+
+    /// Return a string representation
+    std::string toString() const;
+
+    MTS_DECLARE_CLASS()
+protected:
+    /// Virtual destructor
+    virtual ~VCMWorkResult();
+
+    inline int strategyIndex(int s, int t) const {
+        int above = s + t - 2;
+        return s + above * (5 + above) / 2;
+    }
+protected:
+#if VCM_DEBUG == 1
+    ref_vector<ImageBlock> m_debugBlocks;
+#endif
+    ref<ImageBlock> m_block, m_lightImage;
+    
+};
+
+MTS_NAMESPACE_END
+
+#endif /* __VCM_WR_H */

--- a/src/libbidir/SConscript
+++ b/src/libbidir/SConscript
@@ -8,7 +8,7 @@ bidirEnv.Append(CPPDEFINES = [['MTS_BUILD_MODULE', 'MTS_MODULE_BIDIR']])
 
 libbidir = bidirEnv.SharedLibrary('mitsuba-bidir', [
         'common.cpp', 'rsampler.cpp', 'vertex.cpp', 'edge.cpp',
-        'path.cpp', 'verification.cpp', 'util.cpp', 'pathsampler.cpp',
+        'path.cpp', 'pathvcm.cpp', 'verification.cpp', 'util.cpp', 'pathsampler.cpp',
         'mut_bidir.cpp', 'mut_lens.cpp', 'mut_caustic.cpp',
         'mut_mchain.cpp', 'manifold.cpp', 'mut_manifold.cpp'
 ])

--- a/src/libbidir/edge.cpp
+++ b/src/libbidir/edge.cpp
@@ -441,7 +441,7 @@ bool PathEdge::pathConnect(const Scene *scene, const PathEdge *predEdge,
 
 bool PathEdge::pathConnectAndCollapse(const Scene *scene, const PathEdge *predEdge,
         const PathVertex *vs, const PathVertex *vt,
-        const PathEdge *succEdge, int &interactions) {
+        const PathEdge *succEdge, int &interactions, bool ignore_visibility) {
     if (vs->isEmitterSupernode() || vt->isSensorSupernode()) {
         Float radianceTransport   = vt->isSensorSupernode() ? 1.0f : 0.0f,
               importanceTransport = 1-radianceTransport;
@@ -481,7 +481,7 @@ bool PathEdge::pathConnectAndCollapse(const Scene *scene, const PathEdge *predEd
         Float remaining = length;
         medium = vt->getTargetMedium(succEdge, d);
 
-        while (true) {
+        while (true && !ignore_visibility) {
             bool surface = scene->rayIntersectAll(ray, its);
 
             if (surface && (interactions == maxInteractions ||

--- a/src/libbidir/pathvcm.cpp
+++ b/src/libbidir/pathvcm.cpp
@@ -1,0 +1,689 @@
+#include <mitsuba/bidir/path.h>
+#include <mitsuba/bidir/mut_manifold.h>
+#include <mitsuba/bidir/manifold.h>
+
+MTS_NAMESPACE_BEGIN
+
+#define D_EPSILON std::numeric_limits<Float>::min() // to avoid division by 0
+
+#define USE_GENERALIZED_PDF // always turn this on
+#define USE_ROUGHNESS_CORRELATION_HEURISTIC // use correlation kernel shrinkage heuristic if enabled: usually a good idea
+
+void Path::adjustRadius(const PathVertex *va, Float& radius, bool first_merge_only, Float th) {
+#if defined(USE_ROUGHNESS_CORRELATION_HEURISTIC)
+    if(!va || va->type == PathVertex::EInvalid) return;
+    Float roughness = Path::getRoughness(va);
+    bool killed = roughness > 0.f && roughness >= th && first_merge_only;
+    Float shrinkage = roughness == std::numeric_limits<Float>::infinity() || killed ?
+            0.0 : pow(0.5, 10*roughness);
+    radius *= shrinkage;
+#endif
+}
+
+void fillPdfList(const Scene* scene, const Path &emitterSubpath, const Path &sensorSubpath, const PathEdge *connectionEdge, int s, int t,
+        EMeasure vsMeasure, EMeasure vtMeasure,
+        const bool* connectable, bool merge,
+        Float* pdfImp, Float* pdfRad, bool* isNull, bool merge_only, Float th, int nEmitterPaths = 0,
+        Float* accProb = NULL, const Float& radius = 0.0, int* emitterRefIndirection = NULL, int* sensorRefIndirection = NULL) {
+    int k = s + t + 1;
+    // emitter: 0, ..., s  sensor: t, ..., 0
+    // full:    0, 1, ..., s,s+1, ..., k-1, k
+    /* Collect importance transfer area/volume densities from vertices */
+    int pos = 0;
+    pdfImp[pos++] = 1.0;
+
+    auto getEdge = [&](int i) -> const PathEdge* {
+        if (i < s) return emitterSubpath.edge(i);
+        if (i == s) return connectionEdge;
+        return sensorSubpath.edge(s + t - i);
+    };
+
+    auto getVertex = [&](int i) -> const PathVertex* {
+        if (i <= s) return emitterSubpath.vertex(i);
+        return sensorSubpath.vertex(k - i);
+    };
+
+    const PathVertex
+            *vsPred = emitterSubpath.vertexOrNull(s - 1),
+            *vtPred = sensorSubpath.vertexOrNull(t - 1),
+            *vs = emitterSubpath.vertex(s),
+            *vt = sensorSubpath.vertex(t);
+
+    for (int i = 0; i < s; ++i)
+        pdfImp[pos++] = emitterSubpath.vertex(i)->pdf[EImportance]
+            * emitterSubpath.edge(i)->pdf[EImportance];
+
+    if (merge) { // use cached pdf
+        pdfImp[pos++] = vs->pdf[EImportance]
+                * emitterSubpath.edge(s)->pdf[EImportance];
+    } else {
+        pdfImp[pos++] = vs->evalPdf(scene, vsPred, vt, EImportance, vsMeasure) * connectionEdge->pdf[EImportance];
+    }
+
+    if (t > 0) {
+        pdfImp[pos++] = vt->evalPdf(scene, vs, vtPred, EImportance, vtMeasure)
+                * sensorSubpath.edge(t - 1)->pdf[EImportance];
+
+        for (int i = t - 1; i > 0; --i)
+            pdfImp[pos++] = sensorSubpath.vertex(i)->pdf[EImportance]
+                * sensorSubpath.edge(i - 1)->pdf[EImportance];
+    }
+
+    /* Collect radiance transfer area/volume densities from vertices */
+    pos = 0;
+    if (s > 0) {
+        for (int i = 0; i < s - 1; ++i)
+            pdfRad[pos++] = emitterSubpath.vertex(i + 1)->pdf[ERadiance]
+                * emitterSubpath.edge(i)->pdf[ERadiance];
+
+        if (merge) { // use cached pdf
+            pdfRad[pos++] = vs->pdf[ERadiance]
+                    * emitterSubpath.edge(s - 1)->pdf[ERadiance];
+        } else {
+            pdfRad[pos++] = vs->evalPdf(scene, vt, vsPred, ERadiance, vsMeasure)
+                    * emitterSubpath.edge(s - 1)->pdf[ERadiance];
+        }
+    }
+
+
+    pdfRad[pos++] = vt->evalPdf(scene, vtPred, vs, ERadiance, vtMeasure)
+            * connectionEdge->pdf[ERadiance];
+
+    for (int i = t; i > 0; --i)
+        pdfRad[pos++] = sensorSubpath.vertex(i - 1)->pdf[ERadiance]
+            * sensorSubpath.edge(i - 1)->pdf[ERadiance];
+
+    pdfRad[pos++] = 1.0;
+
+
+    /* When the path contains specular surface interactions, it is possible
+       to compute the correct MI weights even without going through all the
+       trouble of computing the proper generalized geometric terms (described
+       in the SIGGRAPH 2012 specular manifolds paper). The reason is that these
+       all cancel out. But to make sure that that's actually true, we need to
+       convert some of the area densities in the 'pdfRad' and 'pdfImp' arrays
+       into the projected solid angle measure */
+    for (int i = 1; i <= k - 3; ++i) {
+        if (!merge && i == s) continue;
+        if (!(connectable[i] && !connectable[i + 1]))
+            continue;
+
+        const PathVertex *cur = getVertex(i);
+        const PathVertex *succ = getVertex(i + 1);
+        const PathEdge *edge = getEdge(i);
+
+        pdfImp[i + 1] *= edge->length * edge->length / std::abs(
+                (succ->isOnSurface() ? dot(edge->d, succ->getGeometricNormal()) : 1) *
+                (cur->isOnSurface() ? dot(edge->d, cur->getGeometricNormal()) : 1));
+    }
+
+    for (int i = k - 1; i >= 3; --i) {
+        if (!merge && i - 1 == s) continue;
+        if (!(connectable[i] && !connectable[i - 1]))
+            continue;
+
+        const PathVertex *cur = getVertex(i);
+        const PathVertex *succ = getVertex(i - 1);
+        const PathEdge *edge = getEdge(i - 1);
+
+        pdfRad[i - 1] *= edge->length * edge->length / std::abs(
+                (succ->isOnSurface() ? dot(edge->d, succ->getGeometricNormal()) : 1) *
+                (cur->isOnSurface() ? dot(edge->d, cur->getGeometricNormal()) : 1));
+    }
+
+    /* One more array sweep before the actual useful work starts -- phew! :)
+       "Collapse" edges/vertices that were caused by BSDF::ENull interactions.
+       The BDPT implementation is smart enough to connect straight through those,
+       so they shouldn't be treated as Dirac delta events in what follows */
+    for (int i = 1; i <= k - 3; ++i) {
+        if (!connectable[i] || !isNull[i + 1])
+            continue;
+
+        int start = i + 1, end = start;
+        while (isNull[end + 1])
+            ++end;
+
+        if (!connectable[end + 1]) {
+            /// The chain contains a non-ENull interaction
+            isNull[start] = false;
+            continue;
+        }
+
+        const PathVertex *before = getVertex(i);
+        const PathVertex *after = getVertex(end + 1);
+
+        Vector d = before->getPosition() - after->getPosition();
+        Float lengthSquared = d.lengthSquared();
+        d /= std::sqrt(lengthSquared);
+
+        Float geoTerm = std::abs(
+                (before->isOnSurface() ? dot(before->getGeometricNormal(), d) : 1) *
+                (after->isOnSurface() ? dot(after->getGeometricNormal(), d) : 1)) / lengthSquared;
+
+        pdfRad[start - 1] *= pdfRad[end] * geoTerm;
+        pdfRad[end] = 1;
+        pdfImp[start] *= pdfImp[end + 1] * geoTerm;
+        pdfImp[end + 1] = 1;
+
+        /* When an ENull chain starts right after the emitter / before the sensor,
+           we must keep track of the reference vertex for direct sampling strategies. */
+        if (start == 2 && emitterRefIndirection)
+            *emitterRefIndirection = end + 1;
+        else if (end == k - 2 && sensorRefIndirection)
+            *sensorRefIndirection = start - 1;
+
+        i = end;
+    }
+
+#if defined(USE_GENERALIZED_PDF)
+    
+    // convert pdfs to generalized pdfs, stepping through specular chains. This is needed for correct VCM weights.
+    ref<SpecularManifold> sm = new SpecularManifold(scene);
+
+    int chain_start = -1;
+
+    for (int i = 1; i <= k - 2; i++) {
+        if (connectable[i] && !connectable[i + 1]) {
+            chain_start = i;
+            continue;
+        } else if (connectable[i] == connectable[i + 1] || chain_start < 0) {
+            continue;
+        }
+
+        Float geoTerm = 1.0;
+        // a specular chain (chain_start+1, ..., i, i+1) is found
+        if (i <= s) { // chain from emitter path
+            geoTerm = sm->G(emitterSubpath, chain_start, i + 1);
+        } else { // chain from sensor path
+            geoTerm = sm->G(sensorSubpath, k - (i + 1), k - chain_start);
+        }
+        pdfImp[i + 1] = pdfImp[chain_start + 1] * geoTerm;
+        pdfImp[chain_start + 1] = Float(1.f);
+
+        pdfRad[chain_start] = pdfRad[i] * geoTerm;
+        pdfRad[i] = Float(1.f);
+    }
+#endif
+    if (!accProb) return;
+
+    Float mergeRadius = Path::estimateSensorMergingRadius(scene, emitterSubpath, sensorSubpath, s, t, nEmitterPaths,
+            radius);
+
+    Float survival_prob = 1.0;
+    
+    /* For VCM: Compute acceptance probability of each vertex. The acceptance probability is 0 if the vertex can not be merged. */
+    for (int i = k; i >= 0; i--) {
+        accProb[i] = Float(0.f);
+        bool in_range = i >= 2 && i <= k - 2;
+        bool mergable = in_range && connectable[i];
+        if (mergable) {
+            Float mergeArea = M_PI * mergeRadius * mergeRadius;
+            accProb[i] = std::min(Float(1.f), pdfImp[i] * mergeArea) * survival_prob;
+            if(merge_only) {
+                survival_prob *= 1-getVertex(i)->evalSelectionProb(scene, getVertex(i-1), ERadiance, th);
+                //printf("%f\n", survival_prob);
+            }
+#if !defined(USE_GENERALIZED_PDF)
+            if (!connectable[i - 1]) accProb[i] = pdfImp[i]; // not a special case anymore in generalized pdf.
+#endif
+            
+            //Path::isConnectable_GBDPT(getVertex(i), th)
+        }
+        if(in_range) {
+            Path::adjustRadius(getVertex(i), mergeRadius, false, th);
+        }
+    }
+}
+
+Float Path::miWeightVCM(const Scene *scene, const Path &emitterSubpath,
+        const PathEdge *connectionEdge, const Path &sensorSubpath,
+        int s, int t, bool sampleDirect, bool lightImage, Float exponent,
+        Float radius, size_t nEmitterPaths, bool merge, bool mergeOnly) {
+
+    int k = s + t + 1, n = k + 1;
+
+    // if(s != 0 || t != 5) return 0; // for debug
+    Float *accProb = (Float *) alloca(n * sizeof (Float));
+
+    const PathVertex
+            *vsPred = emitterSubpath.vertexOrNull(s - 1),
+            *vtPred = sensorSubpath.vertexOrNull(t - 1),
+            *vs = emitterSubpath.vertex(s),
+            *vt = sensorSubpath.vertex(t);
+
+    /* pdfImp[i] and pdfRad[i] store the area/volume density of vertex
+       'i' when sampled from the adjacent vertex in the emitter
+       and sensor direction, respectively. */
+
+    Float ratioEmitterDirect = 0.0f, ratioSensorDirect = 0.0f;
+    Float *pdfImp = (Float *) alloca(n * sizeof (Float)),
+            *pdfRad = (Float *) alloca(n * sizeof (Float));
+    bool *connectable = (bool *) alloca(n * sizeof (bool)),
+            *isNull = (bool *) alloca(n * sizeof (bool));
+
+
+    /* Keep track of which vertices are connectable / null interactions */
+    int pos = 0;
+    for (int i = 0; i <= s; ++i) {
+        const PathVertex *v = emitterSubpath.vertex(i);
+        connectable[pos] = v->isConnectable();
+        isNull[pos] = v->isNullInteraction() && !connectable[pos];
+        pos++;
+    }
+
+    for (int i = t; i >= 0; --i) {
+        const PathVertex *v = sensorSubpath.vertex(i);
+        connectable[pos] = v->isConnectable();
+        isNull[pos] = v->isNullInteraction() && !connectable[pos];
+        pos++;
+    }
+
+    if (k <= 3)
+        sampleDirect = false;
+
+    EMeasure vsMeasure = EArea, vtMeasure = EArea;
+    if (sampleDirect) {
+        /* When direct sampling is enabled, we may be able to create certain
+           connections that otherwise would have failed (e.g. to an
+           orthographic camera or a directional light source) */
+        const AbstractEmitter *emitter = (s > 0 ? emitterSubpath.vertex(1) : vt)->getAbstractEmitter();
+        const AbstractEmitter *sensor = (t > 0 ? sensorSubpath.vertex(1) : vs)->getAbstractEmitter();
+
+        EMeasure emitterDirectMeasure = emitter->getDirectMeasure();
+        EMeasure sensorDirectMeasure = sensor->getDirectMeasure();
+
+        connectable[0] = emitterDirectMeasure != EDiscrete && emitterDirectMeasure != EInvalidMeasure;
+        connectable[1] = emitterDirectMeasure != EInvalidMeasure;
+        connectable[k - 1] = sensorDirectMeasure != EInvalidMeasure;
+        connectable[k] = sensorDirectMeasure != EDiscrete && sensorDirectMeasure != EInvalidMeasure;
+
+        /* The following is needed to handle orthographic cameras &
+           directional light sources together with direct sampling */
+        if (t == 1)
+            vtMeasure = sensor->needsDirectionSample() ? EArea : EDiscrete;
+        else if (s == 1)
+            vsMeasure = emitter->needsDirectionSample() ? EArea : EDiscrete;
+    }
+
+    int emitterRefIndirection = 2, sensorRefIndirection = k - 2;
+
+
+    fillPdfList(scene, emitterSubpath, sensorSubpath, connectionEdge, s, t, vsMeasure, vtMeasure,
+            connectable, merge, pdfImp, pdfRad, isNull, mergeOnly, 0.f, nEmitterPaths, accProb, radius,
+            &emitterRefIndirection, &sensorRefIndirection);
+
+    double initial = 1.0f;
+
+    /* When direct sampling strategies are enabled, we must
+       account for them here as well */
+    if (sampleDirect) {
+        /* Direct connection probability of the emitter */
+        const PathVertex *sample = s > 0 ? emitterSubpath.vertex(1) : vt;
+        const PathVertex *ref = emitterRefIndirection <= s
+                ? emitterSubpath.vertex(emitterRefIndirection) : sensorSubpath.vertex(k - emitterRefIndirection);
+        EMeasure measure = sample->getAbstractEmitter()->getDirectMeasure();
+
+        if (connectable[1] && connectable[emitterRefIndirection])
+            ratioEmitterDirect = ref->evalPdfDirect(scene, sample, EImportance,
+                measure == ESolidAngle ? EArea : measure) / pdfImp[1];
+
+        /* Direct connection probability of the sensor */
+        sample = t > 0 ? sensorSubpath.vertex(1) : vs;
+        ref = sensorRefIndirection <= s ? emitterSubpath.vertex(sensorRefIndirection)
+                : sensorSubpath.vertex(k - sensorRefIndirection);
+        measure = sample->getAbstractEmitter()->getDirectMeasure();
+
+        if (connectable[k - 1] && connectable[sensorRefIndirection])
+            ratioSensorDirect = ref->evalPdfDirect(scene, sample, ERadiance,
+                measure == ESolidAngle ? EArea : measure) / pdfRad[k - 1];
+
+        if (s == 1)
+            initial /= ratioEmitterDirect;
+        else if (t == 1)
+            initial /= ratioSensorDirect;
+    }
+
+    double weight = 1.0, pdf = initial;
+
+    /* With all of the above information, the MI weight can now be computed.
+       Since the goal is to evaluate the power heuristic, the absolute area
+       product density of each strategy is interestingly not required. Instead,
+       an incremental scheme can be used that only finds the densities relative
+       to the (s,t) strategy, which can be done using a linear sweep. For
+       details, refer to the Veach thesis, p.306. */
+
+    auto num_conn_shemes = [&](int i) {
+        return Float(connectable[i] && connectable[i+1] && !mergeOnly ? 1 : 0);
+    };
+    
+    auto getVertex = [&](int i) -> const PathVertex* {
+        if (i <= s) return emitterSubpath.vertexOrNull(i);
+        return sensorSubpath.vertexOrNull(k - i);
+    };
+    
+    auto conn_prob = [&](int i) {
+        return num_conn_shemes(i);
+    };
+    
+    auto merge_prob = [&](int i) {
+        if(i == 0 || i == k) return Float(0.f);
+        return accProb[i + 1];
+    };
+
+    double base_prob_exp = pow(conn_prob(s), exponent) + pow(merge_prob(s) * nEmitterPaths, exponent) + D_EPSILON;
+
+    for (int i = s + 1; i < k; ++i) {
+        double prob_exp = pow(conn_prob(i), exponent) + pow(merge_prob(i) * nEmitterPaths, exponent);
+        double next = pdf * (double) pdfImp[i] / (double) pdfRad[i],
+                value = next;
+
+        if (sampleDirect) {
+            if (i == 1)
+                value *= ratioEmitterDirect;
+            else if (i == sensorRefIndirection)
+                value *= ratioSensorDirect;
+        }
+
+
+        int tPrime = k - i - 1;
+        if ((connectable[i + 1] || isNull[i + 1]) && (lightImage || tPrime > 1)) {
+            weight += pow(value, exponent) * prob_exp / base_prob_exp;
+        }
+
+        pdf = next;
+    }
+
+    /* As above, but now compute pdf[i] with i<s (this is done by
+       evaluating the inverse of the previous expressions). */
+    pdf = initial;
+    for (int i = s - 1; i >= 0; --i) {
+        double prob_exp = pow(conn_prob(i), exponent) + pow(merge_prob(i) * nEmitterPaths, exponent);
+        double next = pdf * (double) pdfRad[i + 1] / (double) pdfImp[i + 1],
+                value = next;
+
+        if (sampleDirect) {
+            if (i == 1)
+                value *= ratioEmitterDirect;
+            else if (i == sensorRefIndirection)
+                value *= ratioSensorDirect;
+        }
+
+        int tPrime = k - i - 1;
+        if ((connectable[i + 1] || isNull[i + 1]) && (lightImage || tPrime > 1)) {
+            weight += pow(value, exponent) * prob_exp / base_prob_exp;
+        }
+
+        pdf = next;
+    }
+    
+    Float total_weight = weight == std::numeric_limits<double>::infinity() ? 0.0 : 1.0 / weight;
+    Float w_merge = pow(merge_prob(s), exponent) / base_prob_exp;
+    Float w_conn = pow(conn_prob(s), exponent) / base_prob_exp;
+    
+    if (merge) return total_weight * w_merge;
+    return total_weight * w_conn;
+}
+
+//Float Path::miWeightBaseNoSweep_GDVCM(const Scene *scene, const Path &emitterSubpath,
+//        const PathEdge *connectionEdge, const Path &sensorSubpath,
+//        const Path& offsetEmitterSubpath, const PathEdge *offsetConnectionEdge,
+//        const Path &offsetSensorSubpath,
+//        int s, int t, bool sampleDirect, bool lightImage, Float jDet,
+//        Float exponent, double geomTermX, double geomTermY, int maxT, float th,
+//        Float radius, size_t nEmitterPaths, bool merge, bool merge_only) {
+//    int k = s + t + 1, n = k + 1;
+//    // for vcm
+//    Float *accProb = (Float *) alloca(n * sizeof (Float));
+//
+//    const PathVertex
+//            *vsPred = emitterSubpath.vertexOrNull(s - 1),
+//            *vtPred = sensorSubpath.vertexOrNull(t - 1),
+//            *vs = emitterSubpath.vertex(s),
+//            *vt = sensorSubpath.vertex(t);
+//
+//    /* pdfImp[i] and pdfRad[i] store the area/volume density of vertex
+//    'i' when sampled from the adjacent vertex in the emitter
+//    and sensor direction, respectively. */
+//
+//    Float ratioEmitterDirect = 0.0f;
+//    Float ratioSensorDirect = 0.0f;
+//    Float *pdfImp = (Float *) alloca(n * sizeof (Float));
+//    Float *pdfRad = (Float *) alloca(n * sizeof (Float));
+//    bool *connectable = (bool *)alloca(n * sizeof (bool));
+//    bool *connectableStrict = (bool *)alloca(n * sizeof (bool));
+//    bool *isNull = (bool *)alloca(n * sizeof (bool));
+//    bool *isEmitter = (bool *)alloca(n * sizeof (bool));
+//
+//    /* Keep track of which vertices are connectable / null interactions */
+//    // a perfectly specular interaction is *not* connectable!
+//    int pos = 0;
+//    for (int i = 0; i <= s; ++i) {
+//        const PathVertex *v = emitterSubpath.vertex(i);
+//        connectable[pos] = Path::isConnectable_GBDPT(v, th);
+//        connectableStrict[pos] = v->isConnectable();
+//        isNull[pos] = v->isNullInteraction() && !connectable[pos];
+//        isEmitter[pos] = v->isEmitterSample();
+//        pos++;
+//    }
+//
+//    for (int i = t; i >= 0; --i) {
+//        const PathVertex *v = sensorSubpath.vertex(i);
+//        connectable[pos] = Path::isConnectable_GBDPT(v, th);
+//        connectableStrict[pos] = v->isConnectable();
+//        isNull[pos] = v->isNullInteraction() && !connectable[pos];
+//        isEmitter[pos] = v->isEmitterSample();
+//        pos++;
+//    }
+//
+//    connectable[s+1] = true; // must force the actual connection to be connectable.
+//    if(!merge) connectable[s] = true;
+//    EMeasure vsMeasure = EArea, vtMeasure = EArea;
+//
+//    fillPdfList(scene, emitterSubpath, sensorSubpath, connectionEdge, s, t, vsMeasure, vtMeasure,
+//            connectableStrict, merge, pdfImp, pdfRad, isNull, merge_only, th, nEmitterPaths, accProb, radius);
+//
+//    double sum_p = 0.f;
+//
+//    auto num_conn_shemes = [&](int i) {
+//        if ((connectableStrict[i] || isNull[i]) && connectableStrict[i+1] && !merge_only) {
+//            return Float(1);
+//        }
+//        return Float(0);
+//    };
+//    
+//    auto getVertex = [&](int i) -> const PathVertex* {
+//        if (i <= s) return emitterSubpath.vertexOrNull(i);
+//        return sensorSubpath.vertexOrNull(k - i);
+//    };
+//    
+//    auto conn_prob = [&](int i) {
+//        if(i <= 1 || i == k) return num_conn_shemes(i);
+//        Float ps = getVertex(i)->evalSelectionProb(scene, getVertex(i-1), EImportance, th);
+//        Float pt = getVertex(i+1)->evalSelectionProb(scene, getVertex(i+2), ERadiance, th);
+//        return ps * pt * num_conn_shemes(i);
+//    };
+//    
+//    auto merge_prob = [&](int i) {
+//        if(i == 0 || i == k) return Float(0.f);
+//        Float pt = getVertex(i+1)->evalSelectionProb(scene, getVertex(i+2), ERadiance, th);
+//        return pt * accProb[i + 1];
+//    };
+//
+//    /* No linear sweep */
+//    double p_i, p_st = 0.0;
+//    for (int p = 0; p < s + t + 1; ++p) {
+//        p_i = 1.f;
+//
+//        for (int i = 1; i < p + 1; ++i) {
+//            p_i *= pdfImp[i];
+//        }
+//
+//        for (int i = p + 1; i < s + t + 1; ++i) {
+//            p_i *= pdfRad[i];
+//        }
+//
+//        int tPrime = k - p - 1;
+//        Float p_conn_merge = std::pow(conn_prob(p), exponent) + pow(nEmitterPaths * merge_prob(p), exponent); // for VCM: Now we have 2 ways to sample this path. 1 is for connection, accProb[i] is for merging
+//
+//        bool allowedToConnect = connectableStrict[p + 1];
+//        if (allowedToConnect && MIScond_GBDPT(tPrime, p, lightImage)) {
+//            sum_p += std::pow(p_i * geomTermX, exponent) * p_conn_merge;
+//        }
+//
+//        if (tPrime == t) {
+//            p_st = std::pow(p_i * geomTermX, exponent) * p_conn_merge;
+//        }
+//    }
+//    Float mergeWeight = std::pow(merge_prob(s), exponent);
+//    Float connWeight = std::pow(conn_prob(s), exponent);
+//    Float totalWeight = std::pow(conn_prob(s), exponent) + 
+//                std::pow(merge_prob(s) * nEmitterPaths, exponent) + D_EPSILON;
+//    
+//    if (sum_p == 0.0) return 0.0;
+//    if (merge) return (Float) (p_st / sum_p * mergeWeight / totalWeight);
+//    return (Float) (p_st / sum_p * connWeight / totalWeight);
+//}
+//
+//Float Path::miWeightGradNoSweep_GDVCM(const Scene *scene, const Path &emitterSubpath,
+//        const PathEdge *connectionEdge, const Path &sensorSubpath,
+//        const Path&offsetEmitterSubpath, const PathEdge *offsetConnectionEdge,
+//        const Path &offsetSensorSubpath,
+//        int s, int t, bool sampleDirect, bool lightImage, Float jDet,
+//        Float exponent, double geomTermX, double geomTermY, int maxT, float th,
+//        Float radius, size_t nEmitterPaths, bool merge, bool merge_only) {
+//    int k = s + t + 1, n = k + 1;
+//    // for vcm
+//    Float *accProb = (Float *) alloca(n * sizeof (Float));
+//    Float *oAccProb = (Float *) alloca(n * sizeof (Float));
+//
+//    Float *pdfImp = (Float *) alloca(n * sizeof (Float));
+//    Float *pdfRad = (Float *) alloca(n * sizeof (Float));
+//    Float *offsetPdfImp = (Float *) alloca(n * sizeof (Float));
+//    Float *offsetPdfRad = (Float *) alloca(n * sizeof (Float));
+//    bool *connectable = (bool *)alloca(n * sizeof (bool));
+//    bool *connectableStrict = (bool *)alloca(n * sizeof (bool));
+//    bool *isNull = (bool *)alloca(n * sizeof (bool));
+//    bool *isEmitter = (bool *)alloca(n * sizeof (bool));
+//
+//    /* Keep track of which vertices are connectable / null interactions */
+//    // a perfectly specular interaction is *not* connectable!
+//    int pos = 0;
+//    for (int i = 0; i <= s; ++i) {
+//        const PathVertex *v = emitterSubpath.vertex(i);
+//        connectable[pos] = Path::isConnectable_GBDPT(v, th);
+//        connectableStrict[pos] = v->isConnectable();
+//        isNull[pos] = v->isNullInteraction() && !connectable[pos];
+//        isEmitter[pos] = v->isEmitterSample();
+//        pos++;
+//    }
+//
+//    for (int i = t; i >= 0; --i) {
+//        const PathVertex *v = sensorSubpath.vertex(i);
+//        connectable[pos] = Path::isConnectable_GBDPT(v, th);
+//        connectableStrict[pos] = v->isConnectable();
+//        isNull[pos] = v->isNullInteraction() && !connectable[pos];
+//        isEmitter[pos] = v->isEmitterSample();
+//        pos++;
+//    }
+//
+//    connectable[s+1] = true; // must force the actual connection to be connectable.
+//    if(!merge) connectable[s] = true;
+//    
+//    EMeasure vsMeasure = EArea, vtMeasure = EArea;
+//
+//    fillPdfList(scene, emitterSubpath, sensorSubpath, connectionEdge, s, t, vsMeasure, vtMeasure,
+//            connectableStrict, merge, pdfImp, pdfRad, isNull, merge_only, th, nEmitterPaths, accProb, radius);
+//
+//    fillPdfList(scene, offsetEmitterSubpath, offsetSensorSubpath, offsetConnectionEdge, s, t, vsMeasure, vtMeasure,
+//            connectableStrict, merge, offsetPdfImp, offsetPdfRad, isNull, merge_only, th, nEmitterPaths, oAccProb, radius);
+//
+//    double sum_p = 0.f, p_st = 0.f;
+//
+//    auto num_conn_shemes = [&](int i) {
+//        if ((connectableStrict[i] || isNull[i]) && connectableStrict[i+1] && !merge_only) {
+//            return Float(1);
+//        }
+//        return Float(0);
+//    };
+//    
+//    auto getVertex = [&](int i) -> const PathVertex* {
+//        if (i <= s) return emitterSubpath.vertexOrNull(i);
+//        return sensorSubpath.vertexOrNull(k - i);
+//    };
+//    
+//    auto conn_prob = [&](int i) {
+//        if(i <= 1 || i == k) return num_conn_shemes(i);
+//        Float ps = getVertex(i)->evalSelectionProb(scene, getVertex(i-1), EImportance, th);
+//        Float pt = getVertex(i+1)->evalSelectionProb(scene, getVertex(i+2), ERadiance, th);
+//        return ps * pt * num_conn_shemes(i);
+//    };
+//    
+//    auto merge_prob = [&](int i) {
+//        if(i == 0 || i == k) return Float(0.f);
+//        Float pt = getVertex(i+1)->evalSelectionProb(scene, getVertex(i+2), ERadiance, th);
+//        return pt * std::pow(accProb[i + 1], exponent);
+//    };
+//    
+//    auto getOffsetVertex = [&](int i) -> const PathVertex* {
+//        if (i <= s) return offsetEmitterSubpath.vertexOrNull(i);
+//        return offsetSensorSubpath.vertexOrNull(k - i);
+//    };
+//    
+//    auto offset_conn_prob = [&](int i) {
+//        if(i <= 1 || i == k) return num_conn_shemes(i);
+//        Float ps = getOffsetVertex(i)->evalSelectionProb(scene, getOffsetVertex(i-1), EImportance, th);
+//        Float pt = getOffsetVertex(i+1)->evalSelectionProb(scene, getOffsetVertex(i+2), ERadiance, th);
+//        return ps * pt * num_conn_shemes(i);
+//    };
+//    
+//    auto offset_merge_prob = [&](int i) {
+//        if(i == 0 || i == k) return Float(0.f);
+//        Float pt = getOffsetVertex(i+1)->evalSelectionProb(scene, getOffsetVertex(i+2), ERadiance, th);
+//        return pt * std::pow(oAccProb[i + 1], exponent);
+//    };
+//
+//    /* No linear sweep */
+//    double value, oValue;
+//    for (int p = 0; p < s + t + 1; ++p) {
+//        value = 1.f;
+//        oValue = 1.f;
+//
+//        for (int i = 1; i < p + 1; ++i) {
+//            value *= pdfImp[i];
+//            oValue *= offsetPdfImp[i];
+//        }
+//
+//        for (int i = p + 1; i < s + t + 1; ++i) {
+//            value *= pdfRad[i];
+//            oValue *= offsetPdfRad[i];
+//        }
+//
+//        Float p_conn_merge = std::pow(conn_prob(p), exponent) + 
+//                std::pow(merge_prob(p) * nEmitterPaths, exponent); // for VCM: Now we have 2 ways to sample this path. 1 is for connection, accProb[i] is for merging
+//
+//        Float op_conn_merge = std::pow(offset_conn_prob(p), exponent) + 
+//                std::pow(offset_merge_prob(p) * nEmitterPaths, exponent);
+//
+//        int tPrime = k - p - 1;
+//        bool allowedToConnect = connectableStrict[p + 1];
+//        if (allowedToConnect && MIScond_GBDPT(tPrime, p, lightImage))
+//            sum_p += std::pow(value * geomTermX, exponent) * p_conn_merge +
+//                std::pow(oValue * jDet * geomTermY, exponent) * op_conn_merge;
+//        if (tPrime == t)
+//            p_st = std::pow(value * geomTermX, exponent) * p_conn_merge;
+//    }
+//
+//    Float mergeWeight = std::pow(merge_prob(s), exponent);
+//    Float connWeight = std::pow(conn_prob(s), exponent);
+//    Float totalWeight = std::pow(conn_prob(s), exponent) + 
+//                std::pow(merge_prob(s) * nEmitterPaths, exponent) + D_EPSILON;
+//
+//    if (sum_p == 0.0) return 0.0;
+//
+//    if (merge)
+//        return (Float) (p_st / sum_p * mergeWeight / totalWeight);
+//    return (Float) (p_st / sum_p * connWeight / totalWeight);
+//}
+
+MTS_NAMESPACE_END
+

--- a/src/librender/bsdf.cpp
+++ b/src/librender/bsdf.cpp
@@ -59,6 +59,10 @@ void BSDF::configure() {
         m_combinedType |= m_components[i];
 }
 
+Float BSDF::selectionProb(const BSDFSamplingRecord &bRec) const {
+    return 1.0f / getComponentCount();
+}
+
 Float BSDF::getEta() const {
     return 1.0f;
 }

--- a/src/librender/renderproc.cpp
+++ b/src/librender/renderproc.cpp
@@ -121,6 +121,7 @@ BlockedRenderProcess::BlockedRenderProcess(const RenderJob *parent, RenderQueue 
     m_pixelFormat = Bitmap::ESpectrumAlphaWeight;
     m_channelCount = -1;
     m_warnInvalid = true;
+    m_preserveProgress = false;
 }
 
 BlockedRenderProcess::~BlockedRenderProcess() {
@@ -174,9 +175,12 @@ void BlockedRenderProcess::bindResource(const std::string &name, int id) {
             Log(EError, "The block size must be larger than the image reconstruction filter radius!");
 
         BlockedImageProcess::init(offset, size, m_blockSize);
-        if (m_progress)
-            delete m_progress;
-        m_progress = new ProgressReporter("Rendering", m_numBlocksTotal, m_parent);
+        if (!m_preserveProgress) {
+          // If this flag is set, the integrator will create its own progress bar - do not do anything
+          if (m_progress)
+              delete m_progress;
+          m_progress = new ProgressReporter("Rendering", m_numBlocksTotal, m_parent);
+        }
     }
     BlockedImageProcess::bindResource(name, id);
 }

--- a/src/mtsgui/resources/docs.xml
+++ b/src/mtsgui/resources/docs.xml
@@ -237,8 +237,7 @@
         </descr>
     </plugin>
 
-    <plugin type="integrator" name="ptracer" readableName="Adjoint particle tracer" show="true"
-            className="ParticleTracer" extends="ImageBasedIntegrator">
+    <plugin type="integrator" name="ptracer" readableName="Adjoint particle tracer" show="true" className="ParticleTracer" extends="ImageBasedIntegrator">
     <descr>
             <p>This plugin implements a simple adjoint particle tracer. It does
             essentially the exact opposite of the simple volumetric path tracer:
@@ -761,32 +760,27 @@
         overhead, since large <em>light images</em> must be transferred between threads
         or over the network. See the main documentation for a more detailed explanation.
       </param>
-      <param name="sampleDirect" readableName="Use direct sampling methods" type="boolean" default="false">
-        Direct sampling is not yet supported in VCM.
-      </param>
       <param name="rrDepth" readableName="Russian Roulette starting depth" type="integer" default="5" importance="1">
         Specifies the minimum path depth, after which the implementation will start to use the
         "russian roulette" path termination criterion (set to <tt>-1</tt> to disable).
       </param>
-      <param name="showWeighted" readableName="showWeight (TODO)" type="boolean" default="false">
-        
+      <param name="initialRadius" readableName="Initial radius" type="float" default="0">
+        Initial photon query radius (<tt>0</tt> = infer based on scene size and camera resolution)
       </param>
-      <param name="initialRadius" readableName="initialRadius (TODO)" type="float" default="0">
-        
-      </param>
-      <param name="radiusReductionAlpha" readableName="radiusReductionAlpha (TODO)" type="float" default="0.95">
-        
+      <param name="radiusReductionAlpha" readableName="Size reduction parameter" type="float" default="0.95">
+        Alpha parameter from PPM (influences the speed, at which the photon radius is reduced)
       </param>
       <param name="phExponent" readableName ="phExponent (TODO)" type="float" default="1.0">
       </param>
-      <param name="mergeOnly" readableName="mergeOnly (TODO)" type="boolean" default="false">
-
+      <param name="mergeOnly" readableName="Merge vertices only" type="boolean" default="false">
+        Only merge vertices instead of both vertices and paths? If this is enabled, it will disable Light Image.
       </param>
-      <param name="metropolis" readableName="metropolis (TODO)" type="boolean" default="false">
-        
+      <param name="metropolis" readableName="Use PSSMLT sampling" type="boolean" default="false">
+        Instead of random walking light paths à la BDPT, allow VCM to enhance sampling by using a subset of Primary Sample Space Metropolis Light Transport (PSSMLT).
+        This option requires Light Image and will enable it if it is not set.
       </param>
     </plugin>
-  
+
     <plugin type="rfilter" readableName="Box filter" name="box" show="true" className="BoxFilter" extends="ReconstructionFilter">
         <descr>Box filter: the fastest, but also about the worst possible
             reconstruction filter, since it is extremely prone to aliasing.

--- a/src/mtsgui/resources/docs.xml
+++ b/src/mtsgui/resources/docs.xml
@@ -744,6 +744,49 @@
         </param>
     </plugin>
 
+    <plugin type="integrator" name="vcm" readableName="Vertex Connection and Merging" show="true" className="VCMIntegrator" extends="Integrator">
+      <descr>
+        <p>DEMO: Vertex Connection and Merging </p>
+      </descr>
+      <param name="maxDepth" readableName="Maximum depth" type="integer" default="-1">
+        Specifies the longest path depth in the generated output image (where <tt>-1</tt>
+        corresponds to ∞). A value of 1 will only render directly visible light sources.
+        2 will lead to single-bounce (direct-only) illumination, and so on.
+      </param>
+      <param name="lightImage" readableName="Create light image" type="boolean" default="true">
+        Include sampling strategies that connect
+        paths traced from emitters directly to the camera? (i.e. what the adjoint particle tracer does)
+        This improves the effectiveness of bidirectional path tracing
+        but severely increases the local and remote communication
+        overhead, since large <em>light images</em> must be transferred between threads
+        or over the network. See the main documentation for a more detailed explanation.
+      </param>
+      <param name="sampleDirect" readableName="Use direct sampling methods" type="boolean" default="false">
+        Direct sampling is not yet supported in VCM.
+      </param>
+      <param name="rrDepth" readableName="Russian Roulette starting depth" type="integer" default="5" importance="1">
+        Specifies the minimum path depth, after which the implementation will start to use the
+        "russian roulette" path termination criterion (set to <tt>-1</tt> to disable).
+      </param>
+      <param name="showWeighted" readableName="showWeight (TODO)" type="boolean" default="false">
+        
+      </param>
+      <param name="initialRadius" readableName="initialRadius (TODO)" type="float" default="0">
+        
+      </param>
+      <param name="radiusReductionAlpha" readableName="radiusReductionAlpha (TODO)" type="float" default="0.95">
+        
+      </param>
+      <param name="phExponent" readableName ="phExponent (TODO)" type="float" default="1.0">
+      </param>
+      <param name="mergeOnly" readableName="mergeOnly (TODO)" type="boolean" default="false">
+
+      </param>
+      <param name="metropolis" readableName="metropolis (TODO)" type="boolean" default="false">
+        
+      </param>
+    </plugin>
+  
     <plugin type="rfilter" readableName="Box filter" name="box" show="true" className="BoxFilter" extends="ReconstructionFilter">
         <descr>Box filter: the fastest, but also about the worst possible
             reconstruction filter, since it is extremely prone to aliasing.


### PR DESCRIPTION
Sun et al. implemented VCM as part of their EGSR'17 paper, "Gradient-Domain Vertex Connection and Merging". Their repo is [here](https://github.com/sunweilun/Mitsuba).

Work list
--
 - [X] Ported VCM to Mitsuba 0.6
 - [ ] Works in
   - [X] Windows (My desktop does not have AVX/FMA3 so I can only check if it compiles)
   - [X] MacOS 
   - [ ] Linux (I don't have a working install, only a VM)
 - [ ] Documentation
   - Lots of comments refer to BDPT because their implementation is based on that integrator
 - [ ] GUI integration
   - I'm working on `docs.xml`
 - [ ] Type cast fixes
   - `size_t` vs `int`, `Float` vs `double`, etc.
 - [X] GUI fixes
   - When the original authors ported BDPT to VCM, they did not notice that VCM re-renders (refines) the whole image in each pass, so the progress bar is full by the time the first pass completes. I've fixed this by setting the number of integrated blocks to `number of samples * number of blocks`.
   - ~~Although it works correctly, the ETA now behaves strangely, as it doesn't converge to a sensible number (it always oscillates). I suspect a race condition in the `Timer` used by the progress meter.~~ This has been fixed too. 