### PR TITLE
Fix Windows build

### DIFF
--- a/build/mitsuba-msvc2017.vcxproj
+++ b/build/mitsuba-msvc2017.vcxproj
@@ -70,9 +70,9 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <NMakePreprocessorDefinitions>WIN32;_DEBUG;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
-    <NMakeBuildCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017-debug.py</NMakeBuildCommandLine>
-    <NMakeReBuildCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017-debug.py -c &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc201-debug.py</NMakeReBuildCommandLine>
-    <NMakeCleanCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017-debug.py -c</NMakeCleanCommandLine>
+    <NMakeBuildCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017-debug.py --debug=stacktrace</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017-debug.py --debug=stacktrace -c &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017-debug.py --debug=stacktrace</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017-debug.py --debug=stacktrace -c</NMakeCleanCommandLine>
     <NMakeOutput>..\dist\mtsgui.exe</NMakeOutput>
     <NMakeIncludeSearchPath>..\include;$(NMakeIncludeSearchPath)</NMakeIncludeSearchPath>
     <NMakeForcedIncludes>$(NMakeForcedIncludes)</NMakeForcedIncludes>
@@ -84,9 +84,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)$(Configuration)\</IntDir>
-    <NMakeBuildCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017.py</NMakeBuildCommandLine>
-    <NMakeReBuildCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017.py -c &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017.py</NMakeReBuildCommandLine>
-    <NMakeCleanCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017.py -c</NMakeCleanCommandLine>
+    <NMakeBuildCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017.py --debug=stacktrace</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017.py -c &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017.py --debug=stacktrace</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017.py -c --debug=stacktrace</NMakeCleanCommandLine>
     <NMakeOutput>..\dist\mtsgui.exe</NMakeOutput>
     <NMakePreprocessorDefinitions>WIN32;NDEBUG;SINGLE_PRECISION;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
     <NMakeIncludeSearchPath>..\include;$(NMakeIncludeSearchPath)</NMakeIncludeSearchPath>
@@ -1174,9 +1174,6 @@
 		<ClCompile Include="..\src\volume\volcache.cpp">
 			</ClCompile>
 		</ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
-  <ImportGroup Label="ExtensionTargets">
-  </ImportGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets"/>
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/data/windows/mitsuba-msvc2017.vcxproj.template
+++ b/data/windows/mitsuba-msvc2017.vcxproj.template
@@ -71,9 +71,9 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <NMakePreprocessorDefinitions>WIN32;_DEBUG;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
-    <NMakeBuildCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017-debug.py</NMakeBuildCommandLine>
-    <NMakeReBuildCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017-debug.py -c &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc201-debug.py</NMakeReBuildCommandLine>
-    <NMakeCleanCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017-debug.py -c</NMakeCleanCommandLine>
+    <NMakeBuildCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017-debug.py --debug=stacktrace</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017-debug.py --debug=stacktrace -c &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017-debug.py --debug=stacktrace</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017-debug.py --debug=stacktrace -c</NMakeCleanCommandLine>
     <NMakeOutput>..\dist\mtsgui.exe</NMakeOutput>
     <NMakeIncludeSearchPath>..\include;$(NMakeIncludeSearchPath)</NMakeIncludeSearchPath>
     <NMakeForcedIncludes>$(NMakeForcedIncludes)</NMakeForcedIncludes>
@@ -85,9 +85,9 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
     <IntDir>$(SolutionDir)$(Configuration)\</IntDir>
-    <NMakeBuildCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017.py</NMakeBuildCommandLine>
-    <NMakeReBuildCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017.py -c &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017.py</NMakeReBuildCommandLine>
-    <NMakeCleanCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017.py -c</NMakeCleanCommandLine>
+    <NMakeBuildCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017.py --debug=stacktrace</NMakeBuildCommandLine>
+    <NMakeReBuildCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017.py --debug=stacktrace -c &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017.py --debug=stacktrace</NMakeReBuildCommandLine>
+    <NMakeCleanCommandLine>cd .. &amp;&amp; scons --parallelize --cfg=build\config-win64-msvc2017.py --debug=stacktrace -c</NMakeCleanCommandLine>
     <NMakeOutput>..\dist\mtsgui.exe</NMakeOutput>
     <NMakePreprocessorDefinitions>WIN32;NDEBUG;SINGLE_PRECISION;$(NMakePreprocessorDefinitions)</NMakePreprocessorDefinitions>
     <NMakeIncludeSearchPath>..\include;$(NMakeIncludeSearchPath)</NMakeIncludeSearchPath>
@@ -115,9 +115,6 @@
   </ItemGroup>
   <ItemGroup Label="Source Files">
   </ItemGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
-  <ImportGroup Label="ExtensionTargets">
-  </ImportGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/src/shapes/ply/ply_parser.hpp
+++ b/src/shapes/ply/ply_parser.hpp
@@ -66,7 +66,12 @@ public:
 
   class scalar_property_definition_callbacks_type
   {
+  #if defined(__MSVC__)
+  #pragma message("TODO: check your MSVC version if it still needs this workaround, @ply_parser.hpp")
+  public:
+  #else
   private:
+  #endif
     template <typename T>
     struct callbacks_element
     {
@@ -81,7 +86,9 @@ public:
       >
     >::type callbacks;
     callbacks callbacks_;
+  #if !defined(__MSVC__)
   public:
+  #endif
     template <typename ScalarType>
     const typename scalar_property_definition_callback_type<ScalarType>::type& get() const
     {
@@ -142,7 +149,12 @@ public:
 
   class list_property_definition_callbacks_type
   {
+  #if defined(__MSVC__)
+  #pragma message("TODO: check your MSVC version if it still needs this workaround too, @ply_parser.hpp")
+  public:
+  #else
   private:
+  #endif
     template <typename T> struct pair_with : boost::mpl::pair<T,boost::mpl::_> {};
     template<typename Sequence1, typename Sequence2>
     struct sequence_product :
@@ -173,7 +185,9 @@ public:
       >
     >::type callbacks;
     callbacks callbacks_;
+  #if !defined(__MSVC__)
   public:
+  #endif
     template <typename SizeType, typename ScalarType>
     typename list_property_definition_callback_type<SizeType, ScalarType>::type& get()
     {


### PR DESCRIPTION
 - Double inclusion of `Microsoft.Cpp.targets`
 - Typo in the clean step of the VS project
 - Added `--debug=stacktrace` in case anyone tries to use a newer version
of SCons (more on this later!)
 - Workaround template bug in VC++ 2017 compiler

Please review and let me know if any bugs arise.