### PR TITLE
Spectral range is 360-830, not 368-830

### DIFF
--- a/doc/compiling.tex
+++ b/doc/compiling.tex
@@ -81,7 +81,7 @@ Off by default.
 \item[\texttt{MTS\_SSE}]Activate optimized SSE routines. On by default.
 \item[\texttt{MTS\_HAS\_COHERENT\_RT}]Include coherent ray tracing support (depends on \texttt{MTS\_SSE}). This flag is activated by default.
 \item[\texttt{MTS\_DEBUG\_FP}]Generated NaNs and overflows will cause floating point exceptions, which can be caught in a debugger. This is slow and mainly meant as a debugging tool for developers. Off by default.
-\item[\texttt{SPECTRUM\_SAMPLES=}$\langle ..\rangle$]This setting defines the number of spectral samples (in the 368-830 $nm$ range) that are used to render scenes. The default is 3 samples, in which case the renderer automatically turns into an RGB-based system. For high-quality spectral rendering, this should be set to 30 or higher.
+\item[\texttt{SPECTRUM\_SAMPLES=}$\langle ..\rangle$]This setting defines the number of spectral samples (in the 360-830 $nm$ range) that are used to render scenes. The default is 3 samples, in which case the renderer automatically turns into an RGB-based system. For high-quality spectral rendering, this should be set to 30 or higher.
 Refer also to \secref{colorspaces}.
 \item[\texttt{SINGLE\_PRECISION}] Do all computation in single precision. This is normally sufficient and therefore used as the default setting.
 \item[\texttt{DOUBLE\_PRECISION}] Do all computation in double precision. This flag is incompatible with


### PR DESCRIPTION
The spectral range mentioned in this document was 368-830, but it should be 360-830 (following what's in spectrum.h).