### PR TITLE
Fixes to `gridvolume` plugin

### DIFF
--- a/src/volume/gridvolume.cpp
+++ b/src/volume/gridvolume.cpp
@@ -123,9 +123,10 @@ public:
          * the file (which had better exist if unserialization
          * occurs on a remote machine).
          */
-         m_sendData = props.getBoolean("sendData", false);
+        m_sendData = props.getBoolean("sendData", false);
 
-         loadFromFile(props.getString("filename"));
+        loadFromFile(props.getString("filename"));
+        configure();
     }
 
     GridDataSource(Stream *stream, InstanceManager *manager)
@@ -209,8 +210,9 @@ public:
             m_sinTheta[i] = std::sin(angle);
             m_densityMap[i] = i/255.0f;
         }
-        m_cosPhi[255] = m_sinPhi[255] = 0;
-        m_cosTheta[255] = m_sinTheta[255] = 0;
+        m_sinTheta[255] = m_sinPhi[255] = 0;
+        m_cosPhi[255] = 1.0f;
+        m_cosTheta[255] = -1.0f;
         m_densityMap[255] = 1.0f;
     }
 


### PR DESCRIPTION
- `configure` was not called from the default constructor
- the sine/cosine lookup tables were wrongly filled on the last element. (used in UInt8 data representation)
