### PR TITLE
Minor ply parsing bug fix.

### DIFF
--- a/src/libcore/thread.cpp
+++ b/src/libcore/thread.cpp
@@ -633,7 +633,9 @@ void Thread::initializeOpenMP(size_t threadCount) {
             }
             const std::string threadName = "Mitsuba: " + thread->getName();
 
-            #if defined(__LINUX__) || defined(__OSX__)
+            #if defined(__LINUX__) 
+                pthread_setname_np(pthread_self(), threadName.c_str());
+            #elif defined(__OSX__)
                 pthread_setname_np(threadName.c_str());
             #elif defined(__WINDOWS__)
                 SetThreadName(threadName.c_str());

--- a/src/shapes/ply/ply_parser.cpp
+++ b/src/shapes/ply/ply_parser.cpp
@@ -142,7 +142,7 @@ bool ply::ply_parser::parse(std::istream& istream)
           std::string& type = type_or_list;
           char space_type_name;
           stringstream >> space_type_name >> std::ws >> name >> std::ws;
-          if (!stringstream || !std::isspace(space_type_name)) {
+          if (!stringstream.eof() || !std::isspace(space_type_name)) {
             if (error_callback_) {
               error_callback_(line_number_, "parse error");
             }


### PR DESCRIPTION
This line was causing ply parsing to fail on mac.

OS: maxOS 10.13.1
Compiler: Apple LLVM version 8.0.0 (clang-800.0.42.1)