### PR TITLE
Fixed partial derivative NaN error for hair

### DIFF
--- a/src/shapes/hair.cpp
+++ b/src/shapes/hair.cpp
@@ -846,6 +846,7 @@ void HairShape::fillIntersectionRecord(const Ray &ray,
     its.p += its.geoFrame.n * (m_kdtree->getRadius() - std::sqrt(local.y*local.y+local.z*local.z));
 
     its.shFrame.n = its.geoFrame.n;
+    coordinateSystem(its.shFrame.n, its.dpdu, its.dpdv);
     its.hasUVPartials = false;
     its.instance = this;
     its.time = ray.time;


### PR DESCRIPTION
This fixes the NaN errors that occurs due to the new generalised shading frame computation for all shapes. This sets the whole shading frame (including the derivatives) to the geometric frame of the hair shape as it was before the generalisation, just that it is a coordinate system constructed from the normal (both shading and geometric normal are the same). 

https://github.com/mitsuba-renderer/mitsuba/blob/0a49106ad17aa01f9465bce17451ac8d674474f1/src/shapes/hair.cpp#L848

It prevents the NaN error caused by this computation for all shapes as dpdu was zero earlier. 

https://github.com/mitsuba-renderer/mitsuba/blob/ce80ddcb6d3fe0a7240f7230d9d148d776292f57/include/mitsuba/render/skdtree.h#L424

The hair ball, straight-hair and hair curls scenes all load but there is still an error with the curly hair scene as the kd tree initialisation fails this assertion in single precision. Therefore, in order to use the curly hair scene, mitsuba needs to be compiled in double precision. 

https://github.com/mitsuba-renderer/mitsuba/blob/6d7d66175ce4b1bcf7a726e46345d9f24cf7e40c/include/mitsuba/core/aabb.h#L66-L69


 #25 #30 
  