### PR TITLE
#Fix missing default value in "field" integrator

### DIFF
--- a/src/integrators/misc/field.cpp
+++ b/src/integrators/misc/field.cpp
@@ -98,6 +98,8 @@ public:
                 m_undefined = Spectrum(props.getFloat("undefined"));
             else
                 m_undefined = props.getSpectrum("undefined", Spectrum(0.0f));
+        } else {
+            m_undefined = Spectrum(0.0f);
         }
 
         if (SPECTRUM_SAMPLES != 3 && (m_field == EUV || m_field == EShadingNormal || m_field == EGeometricNormal


### PR DESCRIPTION
If the parameter "undefined" is non-existent, the default value for this parameter is not set. This leaves memory uninitialized and thus rendering weird results in the end.

A simple initialization fixes the problem.