### PR TITLE
Fix for mtsgui running on OSX Mojave

### DIFF
--- a/src/libhw/nsgldevice.mm
+++ b/src/libhw/nsgldevice.mm
@@ -409,24 +409,25 @@ void NSGLDevice::init(Device *other) {
     m_mutex = new Mutex();
 
     /* Create the device window */
-    m_window = [[NSWindow alloc] initWithContentRect: contentRect
+    dispatch_async(dispatch_get_main_queue(), ^{ m_window = [[NSWindow alloc] initWithContentRect: contentRect
         styleMask: NSTitledWindowMask | NSClosableWindowMask | NSMiniaturizableWindowMask
-        backing: NSBackingStoreBuffered defer: NO];
-    if (m_window == nil)
-        Log(EError, "Could not create window");
+        backing: NSBackingStoreBuffered defer: NO]; 
+		if (m_window == nil)
+		Log(EError, "Could not create window");
 
-    if (m_center)
-        [m_window center];
+		if (m_center)
+		[m_window center];
 
-    /* Create a sub-view as drawing destination and in order to catch events */
-    m_view = [[CustomView alloc] initWithFrame: contentRect];
-    if (m_view == nil)
-        Log(EError, "Could not create view");
+		/* Create a sub-view as drawing destination and in order to catch events */
+		m_view = [[CustomView alloc] initWithFrame: contentRect];
+		if (m_view == nil)
+		Log(EError, "Could not create view");
 
-    [m_view setDevice: this];
-    [[m_window contentView] addSubview: m_view];
-    [m_window setDelegate: m_view];
-    [m_window setAcceptsMouseMovedEvents: YES];
+		[m_view setDevice: this];
+		[[m_window contentView] addSubview: m_view];
+		[m_window setDelegate: m_view];
+		[m_window setAcceptsMouseMovedEvents: YES];
+        }); 
 
     /* Pixel format setup */
     AssertEx(m_redBits == m_blueBits || m_redBits == m_greenBits, "NSGL does not support individual color depths");


### PR DESCRIPTION
The latest version of OS X (Mojave) requires window opening to be done on the main thread (see issue #89). This causes a crash in `nsgldevice.mm`. 

This pull request fixes the issue, by moving the window opening to the main queue, using `dispatch_async(dispatch_get_main_queue()`.