### PR TITLE
Alternative parameter to perform transformation on uv coordinates during a lookup

### DIFF
--- a/include/mitsuba/core/transform.h
+++ b/include/mitsuba/core/transform.h
@@ -255,13 +255,13 @@ public:
                + m_transform.m[3][2] * v.z + m_transform.m[3][3] * v.w;
     }
 
-	inline Point2 transformUVs(const Point2 &v) const {
-		Float x = m_transform.m[0][0] * v.x + m_transform.m[0][1] * v.y
-			+ m_transform.m[0][2];
-		Float y = m_transform.m[1][0] * v.x + m_transform.m[1][1] * v.y
-			+ m_transform.m[1][2];
-		return Point2(x, y);
-	}
+    inline Point2 transformUVs(const Point2 &v) const {
+        Float x = m_transform.m[0][0] * v.x + m_transform.m[0][1] * v.y
+            + m_transform.m[0][2];
+        Float y = m_transform.m[1][0] * v.x + m_transform.m[1][1] * v.y
+            + m_transform.m[1][2];
+        return Point2(x, y);
+    }
 
 	inline Vector2 transformUVsWithoutTranslation(const Point2 &v) const {
 		Float x = m_transform.m[0][0] * v.x + m_transform.m[0][1] * v.y;
@@ -269,9 +269,9 @@ public:
 		return Vector2(x, y);
 	}
 
-	inline Float get(int x, int y) const {
-		return m_transform.m[y][x];
-	}
+    inline Float get(int x, int y) const {
+        return m_transform.m[y][x];
+    }
 
     /**
      * \brief Transform a ray. Assumes that there is no scaling (no temporaries)

--- a/include/mitsuba/core/transform.h
+++ b/include/mitsuba/core/transform.h
@@ -255,6 +255,24 @@ public:
                + m_transform.m[3][2] * v.z + m_transform.m[3][3] * v.w;
     }
 
+	inline Point2 transformUVs(const Point2 &v) const {
+		Float x = m_transform.m[0][0] * v.x + m_transform.m[0][1] * v.y
+			+ m_transform.m[0][2];
+		Float y = m_transform.m[1][0] * v.x + m_transform.m[1][1] * v.y
+			+ m_transform.m[1][2];
+		return Point2(x, y);
+	}
+
+	inline Vector2 transformUVsWithoutTranslation(const Point2 &v) const {
+		Float x = m_transform.m[0][0] * v.x + m_transform.m[0][1] * v.y;
+		Float y = m_transform.m[1][0] * v.x + m_transform.m[1][1] * v.y;
+		return Vector2(x, y);
+	}
+
+	inline Float get(int x, int y) const {
+		return m_transform.m[y][x];
+	}
+
     /**
      * \brief Transform a ray. Assumes that there is no scaling (no temporaries)
      * \remark This function is not available in the Python bindings

--- a/include/mitsuba/render/texture.h
+++ b/include/mitsuba/render/texture.h
@@ -168,7 +168,7 @@ protected:
 
     virtual ~Texture2D();
 protected:
-	Transform m_uvTransform;
+    Transform m_uvTransform;
 };
 
 MTS_NAMESPACE_END

--- a/include/mitsuba/render/texture.h
+++ b/include/mitsuba/render/texture.h
@@ -168,8 +168,7 @@ protected:
 
     virtual ~Texture2D();
 protected:
-    Point2 m_uvOffset;
-    Vector2 m_uvScale;
+	Transform m_uvTransform;
 };
 
 MTS_NAMESPACE_END

--- a/src/librender/texture.cpp
+++ b/src/librender/texture.cpp
@@ -80,15 +80,27 @@ void Texture::serialize(Stream *stream, InstanceManager *manager) const {
 
 Texture2D::Texture2D(const Properties &props) : Texture(props) {
     if (props.getString("coordinates", "uv") == "uv") {
-        m_uvOffset = Point2(
-            props.getFloat("uoffset", 0.0f),
-            props.getFloat("voffset", 0.0f)
-        );
-        Float uvscale = props.getFloat("uvscale", 1.0f);
-        m_uvScale = Vector2(
-            props.getFloat("uscale", uvscale),
-            props.getFloat("vscale", uvscale)
-        );
+		if (props.hasProperty("uvtransform")) {
+			if (props.hasProperty("uoffset") || props.hasProperty("voffset")
+				|| props.hasProperty("uscale") || props.hasProperty("vscale"))
+				SLog(EError, "Both the 'uvtransformation' parameter and uvoffset/uvscale "
+					"information were provided -- only one of them can be specified at a time!");
+
+			m_uvTransform = props.getTransform("uvtransform", Transform());	
+		} else {
+			auto uvOffset = Point2(
+				props.getFloat("uoffset", 0.0f),
+				props.getFloat("voffset", 0.0f)
+			);
+			Float uvscale = props.getFloat("uvscale", 1.0f);
+			auto uvScale = Vector2(
+				props.getFloat("uscale", uvscale),
+				props.getFloat("vscale", uvscale)
+			);
+
+			m_uvTransform = Transform(Matrix4x4(uvScale.x, 0, uvOffset.x, 0, 0, uvScale.y, uvOffset.y, 0, 0, 0, 1, 0, 0, 0, 0, 1));
+		}
+        
     } else {
         Log(EError, "Only UV coordinates are supported at the moment!");
     }
@@ -96,8 +108,7 @@ Texture2D::Texture2D(const Properties &props) : Texture(props) {
 
 Texture2D::Texture2D(Stream *stream, InstanceManager *manager)
  : Texture(stream, manager) {
-    m_uvOffset = Point2(stream);
-    m_uvScale = Vector2(stream);
+	m_uvTransform = Transform(stream);
 }
 
 Texture2D::~Texture2D() {
@@ -105,28 +116,28 @@ Texture2D::~Texture2D() {
 
 void Texture2D::serialize(Stream *stream, InstanceManager *manager) const {
     Texture::serialize(stream, manager);
-    m_uvOffset.serialize(stream);
-    m_uvScale.serialize(stream);
+	m_uvTransform.serialize(stream);
 }
 
 Spectrum Texture2D::eval(const Intersection &its, bool filter) const {
-    Point2 uv = Point2(its.uv.x * m_uvScale.x, its.uv.y * m_uvScale.y) + m_uvOffset;
+	Point2 uv = m_uvTransform.transformUVs(its.uv);
     if (its.hasUVPartials && filter) {
-        return eval(uv,
-            Vector2(its.dudx * m_uvScale.x, its.dvdx * m_uvScale.y),
-            Vector2(its.dudy * m_uvScale.x, its.dvdy * m_uvScale.y));
+		auto uv3dx = m_uvTransform.transformUVsWithoutTranslation(Point2(its.dudx, its.dvdx));
+		auto uv3dy = m_uvTransform.transformUVsWithoutTranslation(Point2(its.dudy, its.dvdy));
+		return eval(uv, uv3dx, uv3dy);
     } else {
         return eval(uv);
     }
 }
 
 void Texture2D::evalGradient(const Intersection &its, Spectrum *gradient) const {
-    Point2 uv = Point2(its.uv.x * m_uvScale.x, its.uv.y * m_uvScale.y) + m_uvOffset;
+    Point2 uv = m_uvTransform.transformUVs(its.uv);
 
     evalGradient(uv, gradient);
 
-    gradient[0] *= m_uvScale.x;
-    gradient[1] *= m_uvScale.y;
+	auto gradient0 = (gradient[0] * m_uvTransform.get(0, 0)) + (gradient[1] * m_uvTransform.get(1, 0));
+	gradient[1] = (gradient[0] * m_uvTransform.get(0, 1)) + (gradient[1] * m_uvTransform.get(1, 1));
+	gradient[0] = gradient0;
 }
 
 void Texture2D::evalGradient(const Point2 &uv, Spectrum *gradient) const {

--- a/src/librender/texture.cpp
+++ b/src/librender/texture.cpp
@@ -80,27 +80,27 @@ void Texture::serialize(Stream *stream, InstanceManager *manager) const {
 
 Texture2D::Texture2D(const Properties &props) : Texture(props) {
     if (props.getString("coordinates", "uv") == "uv") {
-		if (props.hasProperty("uvtransform")) {
-			if (props.hasProperty("uoffset") || props.hasProperty("voffset")
-				|| props.hasProperty("uscale") || props.hasProperty("vscale"))
-				SLog(EError, "Both the 'uvtransformation' parameter and uvoffset/uvscale "
-					"information were provided -- only one of them can be specified at a time!");
+        if (props.hasProperty("uvtransform")) {
+            if (props.hasProperty("uoffset") || props.hasProperty("voffset")
+                || props.hasProperty("uscale") || props.hasProperty("vscale"))
+                SLog(EError, "Both the 'uvtransformation' parameter and uvoffset/uvscale "
+                    "information were provided -- only one of them can be specified at a time!");
 
-			m_uvTransform = props.getTransform("uvtransform", Transform());	
-		} else {
-			auto uvOffset = Point2(
-				props.getFloat("uoffset", 0.0f),
-				props.getFloat("voffset", 0.0f)
-			);
-			Float uvscale = props.getFloat("uvscale", 1.0f);
-			auto uvScale = Vector2(
-				props.getFloat("uscale", uvscale),
-				props.getFloat("vscale", uvscale)
-			);
+            m_uvTransform = props.getTransform("uvtransform", Transform());
+        } else {
+            auto uvOffset = Point2(
+                props.getFloat("uoffset", 0.0f),
+                props.getFloat("voffset", 0.0f)
+            );
+            Float uvscale = props.getFloat("uvscale", 1.0f);
+            auto uvScale = Vector2(
+                props.getFloat("uscale", uvscale),
+                props.getFloat("vscale", uvscale)
+            );
 
-			m_uvTransform = Transform(Matrix4x4(uvScale.x, 0, uvOffset.x, 0, 0, uvScale.y, uvOffset.y, 0, 0, 0, 1, 0, 0, 0, 0, 1));
-		}
-        
+            m_uvTransform = Transform(Matrix4x4(uvScale.x, 0, uvOffset.x, 0, 0, uvScale.y, uvOffset.y, 0, 0, 0, 1, 0, 0, 0, 0, 1));
+        }
+
     } else {
         Log(EError, "Only UV coordinates are supported at the moment!");
     }
@@ -108,7 +108,7 @@ Texture2D::Texture2D(const Properties &props) : Texture(props) {
 
 Texture2D::Texture2D(Stream *stream, InstanceManager *manager)
  : Texture(stream, manager) {
-	m_uvTransform = Transform(stream);
+    m_uvTransform = Transform(stream);
 }
 
 Texture2D::~Texture2D() {
@@ -116,15 +116,15 @@ Texture2D::~Texture2D() {
 
 void Texture2D::serialize(Stream *stream, InstanceManager *manager) const {
     Texture::serialize(stream, manager);
-	m_uvTransform.serialize(stream);
+    m_uvTransform.serialize(stream);
 }
 
 Spectrum Texture2D::eval(const Intersection &its, bool filter) const {
-	Point2 uv = m_uvTransform.transformUVs(its.uv);
+    Point2 uv = m_uvTransform.transformUVs(its.uv);
     if (its.hasUVPartials && filter) {
-		auto uv3dx = m_uvTransform.transformUVsWithoutTranslation(Point2(its.dudx, its.dvdx));
-		auto uv3dy = m_uvTransform.transformUVsWithoutTranslation(Point2(its.dudy, its.dvdy));
-		return eval(uv, uv3dx, uv3dy);
+        auto uv3dx = m_uvTransform.transformUVsWithoutTranslation(Point2(its.dudx, its.dvdx));
+        auto uv3dy = m_uvTransform.transformUVsWithoutTranslation(Point2(its.dudy, its.dvdy));
+        return eval(uv, uv3dx, uv3dy);
     } else {
         return eval(uv);
     }
@@ -135,9 +135,9 @@ void Texture2D::evalGradient(const Intersection &its, Spectrum *gradient) const 
 
     evalGradient(uv, gradient);
 
-	auto gradient0 = (gradient[0] * m_uvTransform.get(0, 0)) + (gradient[1] * m_uvTransform.get(1, 0));
-	gradient[1] = (gradient[0] * m_uvTransform.get(0, 1)) + (gradient[1] * m_uvTransform.get(1, 1));
-	gradient[0] = gradient0;
+    auto gradient0 = (gradient[0] * m_uvTransform.get(0, 0)) + (gradient[1] * m_uvTransform.get(1, 0));
+    gradient[1] = (gradient[0] * m_uvTransform.get(0, 1)) + (gradient[1] * m_uvTransform.get(1, 1));
+    gradient[0] = gradient0;
 }
 
 void Texture2D::evalGradient(const Point2 &uv, Spectrum *gradient) const {

--- a/src/textures/bitmap.cpp
+++ b/src/textures/bitmap.cpp
@@ -667,15 +667,15 @@ public:
 
     void resolve(const GPUProgram *program, const std::string &evalName, std::vector<int> &parameterIDs) const {
         parameterIDs.push_back(program->getParameterID(evalName + "_texture", false));
-		parameterIDs.push_back(program->getParameterID(evalName + "_uvTransform", false));
-	}
+        parameterIDs.push_back(program->getParameterID(evalName + "_uvTransform", false));
+    }
 
     void bind(GPUProgram *program, const std::vector<int> &parameterIDs,
         int &textureUnitOffset) const {
         m_gpuTexture->bind(textureUnitOffset++);
         program->setParameter(parameterIDs[0], m_gpuTexture.get());
-		program->setParameter(parameterIDs[1], m_uvTransform);
-	}
+        program->setParameter(parameterIDs[1], m_uvTransform);
+    }
 
     void unbind() const {
         m_gpuTexture->unbind();
@@ -684,7 +684,7 @@ public:
     MTS_DECLARE_CLASS()
 private:
     ref<GPUTexture> m_gpuTexture;
-	Transform m_uvTransform;
+    Transform m_uvTransform;
 };
 
 Shader *BitmapTexture::createShader(Renderer *renderer) const {

--- a/src/textures/checkerboard.cpp
+++ b/src/textures/checkerboard.cpp
@@ -36,6 +36,9 @@ MTS_NAMESPACE_BEGIN
  *     \parameter{uscale, vscale}{\Float}{
  *       Multiplicative factors that should be applied to UV values before a lookup
  *     }
+ *     \parameter{uvtransform}{\Transform}{
+ *        Alternate parameter to uvscale/uvoffset parameters that applies a transformation to UV values before a lookup
+ *     }
  * }
  * \renderings{
  *     \rendering{Checkerboard applied to the material test object
@@ -132,10 +135,10 @@ protected:
 class CheckerboardShader : public Shader {
 public:
     CheckerboardShader(Renderer *renderer, const Spectrum &color0,
-        const Spectrum &color1, const Point2 &uvOffset,
-        const Vector2 &uvScale) : Shader(renderer, ETextureShader),
+        const Spectrum &color1, 
+		const Transform &uvTransform) : Shader(renderer, ETextureShader),
         m_color0(color0), m_color1(color1),
-        m_uvOffset(uvOffset), m_uvScale(uvScale) {
+        m_uvTransform(uvTransform) {
     }
 
     void generateCode(std::ostringstream &oss,
@@ -143,13 +146,12 @@ public:
             const std::vector<std::string> &depNames) const {
         oss << "uniform vec3 " << evalName << "_color0;" << endl
             << "uniform vec3 " << evalName << "_color1;" << endl
-            << "uniform vec2 " << evalName << "_uvOffset;" << endl
-            << "uniform vec2 " << evalName << "_uvScale;" << endl
+            << "uniform mat4 " << evalName << "_uvTransform;" << endl
             << endl
             << "vec3 " << evalName << "(vec2 uv) {" << endl
             << "    uv = vec2(" << endl
-            << "        uv.x * " << evalName << "_uvScale.x + " << evalName << "_uvOffset.x," << endl
-            << "        uv.y * " << evalName << "_uvScale.y + " << evalName << "_uvOffset.y);" << endl
+            << "        uv.x * " << evalName << "_uvTransform[0][0] + uv.y * " << evalName << "_uvTransform[1][0] + " << evalName << "_uvTransform[2][0]," << endl
+			<< "        uv.x * " << evalName << "_uvTransform[0][1] + uv.y * " << evalName << "_uvTransform[1][1] + " << evalName << "_uvTransform[2][1]);" << endl
             << "    float x = 2*(mod(int(uv.x*2), 2)) - 1, y = 2*(mod(int(uv.y*2), 2)) - 1;" << endl
             << "    if (x*y == 1)" << endl
             << "        return " << evalName << "_color0;" << endl
@@ -161,29 +163,26 @@ public:
     void resolve(const GPUProgram *program, const std::string &evalName, std::vector<int> &parameterIDs) const {
         parameterIDs.push_back(program->getParameterID(evalName + "_color0", false));
         parameterIDs.push_back(program->getParameterID(evalName + "_color1", false));
-        parameterIDs.push_back(program->getParameterID(evalName + "_uvOffset", false));
-        parameterIDs.push_back(program->getParameterID(evalName + "_uvScale", false));
+        parameterIDs.push_back(program->getParameterID(evalName + "_uvTransform", false));
     }
 
     void bind(GPUProgram *program, const std::vector<int> &parameterIDs,
         int &textureUnitOffset) const {
         program->setParameter(parameterIDs[0], m_color0);
         program->setParameter(parameterIDs[1], m_color1);
-        program->setParameter(parameterIDs[2], m_uvOffset);
-        program->setParameter(parameterIDs[3], m_uvScale);
+        program->setParameter(parameterIDs[2], m_uvTransform);
     }
 
     MTS_DECLARE_CLASS()
 private:
     Spectrum m_color0;
     Spectrum m_color1;
-    Point2 m_uvOffset;
-    Vector2 m_uvScale;
+	Transform m_uvTransform;
 };
 
 Shader *Checkerboard::createShader(Renderer *renderer) const {
     return new CheckerboardShader(renderer, m_color0, m_color1,
-        m_uvOffset, m_uvScale);
+        m_uvTransform);
 }
 
 MTS_IMPLEMENT_CLASS(CheckerboardShader, false, Shader)

--- a/src/textures/checkerboard.cpp
+++ b/src/textures/checkerboard.cpp
@@ -136,7 +136,7 @@ class CheckerboardShader : public Shader {
 public:
     CheckerboardShader(Renderer *renderer, const Spectrum &color0,
         const Spectrum &color1, 
-		const Transform &uvTransform) : Shader(renderer, ETextureShader),
+        const Transform &uvTransform) : Shader(renderer, ETextureShader),
         m_color0(color0), m_color1(color1),
         m_uvTransform(uvTransform) {
     }
@@ -151,7 +151,7 @@ public:
             << "vec3 " << evalName << "(vec2 uv) {" << endl
             << "    uv = vec2(" << endl
             << "        uv.x * " << evalName << "_uvTransform[0][0] + uv.y * " << evalName << "_uvTransform[1][0] + " << evalName << "_uvTransform[2][0]," << endl
-			<< "        uv.x * " << evalName << "_uvTransform[0][1] + uv.y * " << evalName << "_uvTransform[1][1] + " << evalName << "_uvTransform[2][1]);" << endl
+            << "        uv.x * " << evalName << "_uvTransform[0][1] + uv.y * " << evalName << "_uvTransform[1][1] + " << evalName << "_uvTransform[2][1]);" << endl
             << "    float x = 2*(mod(int(uv.x*2), 2)) - 1, y = 2*(mod(int(uv.y*2), 2)) - 1;" << endl
             << "    if (x*y == 1)" << endl
             << "        return " << evalName << "_color0;" << endl
@@ -177,7 +177,7 @@ public:
 private:
     Spectrum m_color0;
     Spectrum m_color1;
-	Transform m_uvTransform;
+    Transform m_uvTransform;
 };
 
 Shader *Checkerboard::createShader(Renderer *renderer) const {

--- a/src/textures/gridtexture.cpp
+++ b/src/textures/gridtexture.cpp
@@ -149,7 +149,7 @@ class GridTextureShader : public Shader {
 public:
     GridTextureShader(Renderer *renderer, const Spectrum &color0,
         const Spectrum &color1, Float lineWidth, 
-		const Transform &uvTransform) : Shader(renderer, ETextureShader),
+        const Transform &uvTransform) : Shader(renderer, ETextureShader),
         m_color0(color0), m_color1(color1),
         m_lineWidth(lineWidth), m_uvTransform(uvTransform) {
     }
@@ -164,8 +164,8 @@ public:
             << endl
             << "vec3 " << evalName << "(vec2 uv) {" << endl
             << "    uv = vec2(" << endl
-			<< "        uv.x * " << evalName << "_uvTransform[0][0] + uv.y * " << evalName << "_uvTransform[1][0] + " << evalName << "_uvTransform[2][0]," << endl
-			<< "        uv.x * " << evalName << "_uvTransform[0][1] + uv.y * " << evalName << "_uvTransform[1][1] + " << evalName << "_uvTransform[2][1]);" << endl
+            << "        uv.x * " << evalName << "_uvTransform[0][0] + uv.y * " << evalName << "_uvTransform[1][0] + " << evalName << "_uvTransform[2][0]," << endl
+            << "        uv.x * " << evalName << "_uvTransform[0][1] + uv.y * " << evalName << "_uvTransform[1][1] + " << evalName << "_uvTransform[2][1]);" << endl
             << "    float x = uv.x - floor(uv.x);" << endl
             << "    float y = uv.y - floor(uv.y);" << endl
             << "    if (x > .5) x -= 1.0;" << endl

--- a/src/textures/gridtexture.cpp
+++ b/src/textures/gridtexture.cpp
@@ -43,6 +43,9 @@ MTS_NAMESPACE_BEGIN
  *     \parameter{uoffset, voffset}{\Float}{
  *       Numerical offset that should be applied to UV values before a lookup
  *     }
+ *     \parameter{uvtransform}{\Transform}{
+ *        Alternate parameter to uvscale/uvoffset parameters that applies a transformation to UV values before a lookup
+ *     }
  * }
  * \renderings{
  *     \rendering{Grid texture applied to the material test object}{tex_gridtexture}
@@ -145,10 +148,10 @@ protected:
 class GridTextureShader : public Shader {
 public:
     GridTextureShader(Renderer *renderer, const Spectrum &color0,
-        const Spectrum &color1, Float lineWidth, const Point2 &uvOffset,
-        const Vector2 &uvScale) : Shader(renderer, ETextureShader),
+        const Spectrum &color1, Float lineWidth, 
+		const Transform &uvTransform) : Shader(renderer, ETextureShader),
         m_color0(color0), m_color1(color1),
-        m_lineWidth(lineWidth), m_uvOffset(uvOffset), m_uvScale(uvScale) {
+        m_lineWidth(lineWidth), m_uvTransform(uvTransform) {
     }
 
     void generateCode(std::ostringstream &oss,
@@ -157,13 +160,12 @@ public:
         oss << "uniform vec3 " << evalName << "_color0;" << endl
             << "uniform vec3 " << evalName << "_color1;" << endl
             << "uniform float " << evalName << "_lineWidth;" << endl
-            << "uniform vec2 " << evalName << "_uvOffset;" << endl
-            << "uniform vec2 " << evalName << "_uvScale;" << endl
+			<< "uniform mat4 " << evalName << "_uvTransform;" << endl
             << endl
             << "vec3 " << evalName << "(vec2 uv) {" << endl
             << "    uv = vec2(" << endl
-            << "        uv.x * " << evalName << "_uvScale.x + " << evalName << "_uvOffset.x," << endl
-            << "        uv.y * " << evalName << "_uvScale.y + " << evalName << "_uvOffset.y);" << endl
+			<< "        uv.x * " << evalName << "_uvTransform[0][0] + uv.y * " << evalName << "_uvTransform[1][0] + " << evalName << "_uvTransform[2][0]," << endl
+			<< "        uv.x * " << evalName << "_uvTransform[0][1] + uv.y * " << evalName << "_uvTransform[1][1] + " << evalName << "_uvTransform[2][1]);" << endl
             << "    float x = uv.x - floor(uv.x);" << endl
             << "    float y = uv.y - floor(uv.y);" << endl
             << "    if (x > .5) x -= 1.0;" << endl
@@ -179,8 +181,7 @@ public:
         parameterIDs.push_back(program->getParameterID(evalName + "_color0", false));
         parameterIDs.push_back(program->getParameterID(evalName + "_color1", false));
         parameterIDs.push_back(program->getParameterID(evalName + "_lineWidth", false));
-        parameterIDs.push_back(program->getParameterID(evalName + "_uvOffset", false));
-        parameterIDs.push_back(program->getParameterID(evalName + "_uvScale", false));
+        parameterIDs.push_back(program->getParameterID(evalName + "_uvTransform", false));
     }
 
     void bind(GPUProgram *program, const std::vector<int> &parameterIDs,
@@ -188,8 +189,7 @@ public:
         program->setParameter(parameterIDs[0], m_color0);
         program->setParameter(parameterIDs[1], m_color1);
         program->setParameter(parameterIDs[2], m_lineWidth);
-        program->setParameter(parameterIDs[3], m_uvOffset);
-        program->setParameter(parameterIDs[4], m_uvScale);
+        program->setParameter(parameterIDs[3], m_uvTransform);
     }
 
     MTS_DECLARE_CLASS()
@@ -197,13 +197,12 @@ private:
     Spectrum m_color0;
     Spectrum m_color1;
     Float m_lineWidth;
-    Point2 m_uvOffset;
-    Vector2 m_uvScale;
+    Transform m_uvTransform;
 };
 
 Shader *GridTexture::createShader(Renderer *renderer) const {
     return new GridTextureShader(renderer, m_color0, m_color1,
-            m_lineWidth, m_uvOffset, m_uvScale);
+            m_lineWidth, m_uvTransform);
 }
 
 MTS_IMPLEMENT_CLASS(GridTextureShader, false, Shader)


### PR DESCRIPTION
Adds a uvtransformation parameter to the plugins bitmap, checkerboard and gridtexture that can be used as an alternative to uvscale and uvoffset. It would help in cases where, for example, rotating uv coordinates would be necessary. Or was there a special reason only translation and scaling where chosen as uv operations for mitsuba?