### PR TITLE
Optimized complexity of the MemoryStream write operation.

### DIFF
--- a/src/libcore/mstream.cpp
+++ b/src/libcore/mstream.cpp
@@ -102,7 +102,7 @@ void MemoryStream::write(const void *ptr, size_t size) {
     size_t endPos = m_pos + size;
     if (endPos > m_size) {
         if (endPos > m_capacity)
-            resize(endPos);
+            resize(endPos * 2);
         m_size = endPos;
     }
     memcpy(m_data + m_pos, ptr, size);


### PR DESCRIPTION
Optimized complexity of the MemoryStream write operation. Before complexity of the MemoryStream write operation was O(n) now it is
O(log(n)). Complexity gets amortized to O(1) in case of large number of write
operations.

This change solves issue that occurs when the user has 100MB environment map,
which causes Mitsuba renderer to serialize the environment in 20 minutes. Slowdown
occurs when user tries to render the scene with the large environment map using
distributed rendering with multiple machines in the network.