### PR TITLE
fix: buffer overrun in non-symmetric transpose

### DIFF
--- a/include/mitsuba/core/matrix.h
+++ b/include/mitsuba/core/matrix.h
@@ -412,8 +412,8 @@ public:
 
     /// Compute the transpose of this matrix
     inline void transpose(Matrix<N, M, T> &target) const {
-        for (int i=0; i<M; ++i)
-            for (int j=0; j<N; ++j)
+        for (int i=0; i<N; ++i)
+            for (int j=0; j<M; ++j)
                 target.m[i][j] = m[j][i];
     }
 


### PR DESCRIPTION
Row / column bounds did not match matrices in transpose()