### PR TITLE
Exclude photons in opposite side

### DIFF
--- a/src/librender/gatherproc.cpp
+++ b/src/librender/gatherproc.cpp
@@ -142,6 +142,10 @@ public:
         int bsdfType = its.getBSDF()->getType(), depth = depth_ - nullInteractions;
         if (!(bsdfType & BSDF::EDiffuseReflection) && !(bsdfType & BSDF::EGlossyReflection))
             return;
+        
+        /* Do not include photons in opposite side */
+        if (dot(its.geoFrame.n, its.toWorld(its.wi)) <= 0)
+            return;
 
         if ((m_type == GatherPhotonProcess::ECausticPhotons && depth > 1 && delta)
          || (m_type == GatherPhotonProcess::ESurfacePhotons && depth > 1 && !delta)


### PR DESCRIPTION
This PR fixes the problem of the wrong radius update (#145).

I added three lines of code that prevent photons to be stored in KD-tree when the surface normal and the incoming direction of a photon is not on the same side.

Below is the results before/after the change
(_Breakfast Room_ from [link](https://benedikt-bitterli.me/resources/), iteration=100, photons per iteration=250K)
**Before**
![image](https://user-images.githubusercontent.com/43630902/122362253-f0f9a700-cf92-11eb-9444-59baad54b010.png)

**After**
![image](https://user-images.githubusercontent.com/43630902/122362277-f5be5b00-cf92-11eb-8440-c89d3da0e3fe.png)

After the change, it's less noisy due to the larger radius than before.