### PR TITLE
Python 3 compatibility for building qt

### DIFF
--- a/data/scons/qt5.py
+++ b/data/scons/qt5.py
@@ -135,23 +135,25 @@ class _Automoc:
                 out_sources = source[:]
 
                 for obj in source:
-                        if isinstance(obj,basestring):  # big kludge!
-                                print "scons: qt5: '%s' MAYBE USING AN OLD SCONS VERSION AND NOT CONVERTED TO 'File'. Discarded." % str(obj)
+                        if isinstance(obj,str):  # big kludge!
+                                print("scons: qt5: '%s' MAYBE USING AN OLD SCONS VERSION AND NOT CONVERTED TO 'File'. Discarded." % str(obj))
                                 continue
                         if not obj.has_builder():
                                 # binary obj file provided
                                 if debug:
-                                        print "scons: qt: '%s' seems to be a binary. Discarded." % str(obj)
+                                        print("scons: qt: '%s' seems to be a binary. Discarded." % str(obj))
                                 continue
                         cpp = obj.sources[0]
                         if not splitext(str(cpp))[1] in cxx_suffixes:
                                 if debug:
-                                        print "scons: qt: '%s' is no cxx file. Discarded." % str(cpp)
+                                        print("scons: qt: '%s' is no cxx file. Discarded." % str(cpp))
                                 # c or fortran source
                                 continue
                         #cpp_contents = comment.sub('', cpp.get_contents())
                         try:
                                 cpp_contents = cpp.get_contents()
+                                if not isinstance(cpp_contents, str):
+                                        cpp_contents = str(cpp_contents)
                         except: continue # may be an still not generated source
                         h=None
                         for h_ext in header_extensions:
@@ -161,12 +163,14 @@ class _Automoc:
                                 h = find_file(hname, (cpp.get_dir(),), env.File)
                                 if h:
                                         if debug:
-                                                print "scons: qt: Scanning '%s' (header of '%s')" % (str(h), str(cpp))
+                                                print("scons: qt: Scanning '%s' (header of '%s')" % (str(h), str(cpp)))
                                         #h_contents = comment.sub('', h.get_contents())
                                         h_contents = h.get_contents()
+                                        if not isinstance(h_contents, str):
+                                                h_contents = str(h_contents)
                                         break
                         if not h and debug:
-                                print "scons: qt: no header for '%s'." % (str(cpp))
+                                print("scons: qt: no header for '%s'." % (str(cpp)))
                         if h and q_object_search.search(h_contents):
                                 # h file with the Q_OBJECT macro found -> add moc_cpp
                                 moc_cpp = env.Moc5(h)
@@ -174,14 +178,14 @@ class _Automoc:
                                 out_sources.append(moc_o)
                                 #moc_cpp.target_scanner = SCons.Defaults.CScan
                                 if debug:
-                                        print "scons: qt: found Q_OBJECT macro in '%s', moc'ing to '%s'" % (str(h), str(moc_cpp))
+                                        print("scons: qt: found Q_OBJECT macro in '%s', moc'ing to '%s'" % (str(h), str(moc_cpp)))
                         if cpp and q_object_search.search(cpp_contents):
                                 # cpp file with Q_OBJECT macro found -> add moc
                                 # (to be included in cpp)
                                 moc = env.Moc5(cpp)
                                 env.Ignore(moc, moc)
                                 if debug:
-                                        print "scons: qt: found Q_OBJECT macro in '%s', moc'ing to '%s'" % (str(cpp), str(moc))
+                                        print("scons: qt: found Q_OBJECT macro in '%s', moc'ing to '%s'" % (str(cpp), str(moc)))
                                 #moc.source_scanner = SCons.Defaults.CScan
                 # restore the original env attributes (FIXME)
                 objBuilder.env = objBuilderEnv
@@ -303,6 +307,8 @@ def generate(env):
                                         result.append(itemPath)
                         return result
                 contents = node.get_contents()
+                if not isinstance(contents, str):
+                        contents = str(contents)
                 includes = qrcinclude_re.findall(contents)
                 qrcpath = os.path.dirname(node.path)
                 dirs = [included for included in includes if os.path.isdir(os.path.join(qrcpath,included))]

--- a/src/mtsgui/SConscript
+++ b/src/mtsgui/SConscript
@@ -3,10 +3,10 @@ Import('env', 'os', 'glob', 'sys', 'hasQt', 'hasCollada', 'hasBreakpad', 'mainEn
 
 # For running Uic & Moc (below)
 def recursiveDirs(root) :
-        return filter((lambda a : a.rfind(".svn") == -1), [a[0] for a in os.walk(root)])
+        return list(filter((lambda a : a.rfind(".svn") == -1), [a[0] for a in os.walk(root)]))
 
-def unique(list) :
-        return dict.fromkeys(list).keys()
+def unique(l) :
+        return list(dict.fromkeys(l).keys())
 
 def scanFiles(dir, accept=["*.cpp"], reject=[]) :
         sources = []
@@ -15,15 +15,15 @@ def scanFiles(dir, accept=["*.cpp"], reject=[]) :
                 for pattern in accept :
                         sources+=glob.glob(path + "/" + pattern)
         for pattern in reject:
-                sources = filter((lambda a : a.rfind(pattern) == -1), sources)
-        sources = map((lambda a : os.path.basename(a)), sources)
+                sources = list(filter((lambda a : a.rfind(pattern) == -1), sources))
+        sources = list(map((lambda a : os.path.basename(a)), sources))
         return unique(sources)
 
 
 if hasQt:
         qtEnv = mainEnv.Clone()
         qtEnv.Append(CPPPATH=['#src/mtsgui'])
-        if qtEnv.has_key('QTINCLUDE'):
+        if 'QTINCLUDE' in qtEnv:
                 qtEnv.Prepend(CPPPATH=qtEnv['QTINCLUDE'])
         qtEnv.EnableQt5Modules(['QtGui', 'QtWidgets', 'QtCore', 'QtOpenGL', 'QtXml', 'QtXmlPatterns', 'QtNetwork'])
 
@@ -51,9 +51,9 @@ if hasQt:
 
         if hasCollada:
                 qtSources += converter_objects
-                if env.has_key('COLLADALIBDIR'):
+                if 'COLLADALIBDIR' in env:
                         qtEnv.Prepend(LIBPATH=env['COLLADALIBDIR'])
-                if env.has_key('COLLADALIB'):
+                if 'COLLADALIB' in env:
                         qtEnv.Prepend(LIBS=env['COLLADALIB'])
 
         if sys.platform == 'darwin':


### PR DESCRIPTION
As discussed in this [issue](https://github.com/mitsuba-renderer/mitsuba/issues/150), I fixed two files to make enable building mtsgui.exe with python 3.