### PR TITLE
SCons: prefer `dependencies/version.txt`

### DIFF
--- a/build/SConscript.configure
+++ b/build/SConscript.configure
@@ -280,7 +280,9 @@ else:
 Export('MTS_VERSION')
 
 if needsBuildDependencies:
-        versionFilename = GetBuildPath('#dependencies/version')
+        versionFilename = GetBuildPath('#dependencies/version.txt')
+        if not os.path.exists(versionFilename):
+            versionFilename = GetBuildPath('#dependencies/version')
         versionMismatch = False
 
         if not os.path.exists(versionFilename):


### PR DESCRIPTION
Hi @wjakob,

This small change (together with https://github.com/mitsuba-renderer/dependencies_macos/pull/1) should resolve a header naming conflict on macOS, discussed in https://github.com/mitsuba-renderer/mitsuba/issues/156#issuecomment-1114627696.