### PR TITLE
Fix unable detect qt5 by using high version scons to build

### DIFF
--- a/data/scons/qt5.py
+++ b/data/scons/qt5.py
@@ -44,7 +44,12 @@ import SCons.Scanner
 import SCons.Tool
 import SCons.Util
 
-class ToolQtWarning(SCons.Warnings.Warning):
+try: 
+        BaseWarning = SCons.Warnings.Warning
+except AttributeError: 
+        BaseWarning = SCons.Warnings.SConsWarning 
+
+class ToolQtWarning(BaseWarning):
         pass
 
 class GeneratedMocFileNotIncluded(ToolQtWarning):


### PR DESCRIPTION
I use Python3 and Scons-v4.3 to build the mitsuba, but was unable to detect the qt5 when building.
I try to get the exception from qt5.py, and I find that SCons.Warnings do not have the attribute of Warning
When I search the document of Scons-v4.0.1, I see the `Warning` is inherited from `Errors.UserError` and has subclass `WarningOnByDefault`
![image](https://user-images.githubusercontent.com/33982478/177281223-10914e5e-7067-4d04-8ea9-2c0b43dfc6b8.png)
However, from version v4.1.0, I can't find the `Warning` in the document, instead I find class `SConsWarning` is inherited from ```Errors.UserError``` and has subclass `WarningOnByDefault`
![image](https://user-images.githubusercontent.com/33982478/177281661-55819517-2ab4-473d-b395-6149e5f19597.png)
![image](https://user-images.githubusercontent.com/33982478/177282329-e717f120-f8c4-4b64-b6c4-ce2d9f324bf0.png)
So I change the qt5.py so that it can run in high version Scons and keep it compatible with the low versions.