### PR TITLE
Fix typos in doc/ subdirectory

### DIFF
--- a/doc/basics.tex
+++ b/doc/basics.tex
@@ -228,7 +228,7 @@ number of other  machines running \code{mtssrv}, and each of these might also
 share their work with further machines, and so on...
 
 The parallelization over such hierarchies happens transparently: when
-connecting a renderering process to the root node, it sees a machine
+connecting a rendering process to the root node, it sees a machine
 with hundreds or thousands of cores, to which it can submit work without
 needing to worry about how exactly it is going to be spread out in
 the hierarchy.

--- a/doc/compiling.tex
+++ b/doc/compiling.tex
@@ -24,7 +24,7 @@ Begin by entering the following at the command prompt (or run an equivalent comm
 \begin{shell}
 $\texttt{\$}$ git clone https://github.com/mitsuba-renderer/mitsuba
 \end{shell}
-This should dowload a full copy of the main repository.
+This should download a full copy of the main repository.
 
 \subsubsection{Build configurations}
 Common to all platforms is that a build configuration file must be selected. Several options are
@@ -136,7 +136,7 @@ The preferred way of redistributing executables on Debian or Ubuntu Linux is to 
 that you work with a pristine installation of the target operating system\footnote{Several commercial graphics
 drivers ``pollute'' the OpenGL setup so that the compiled Mitsuba binaries
 can only be used on machines using the same drivers. For this reason, it is
-better to work from a clean boostrapped install.}. This can be done as follows:
+better to work from a clean bootstrapped install.}. This can be done as follows:
 first, install \code{debootstrap} and download the most recent operating system release
 to a subdirectory. The following example is based on Ubuntu 12.04 LTS (``Precise Pangolin''),
 but the steps are almost identical for other versions of Ubuntu or Debian Linux.
@@ -174,7 +174,7 @@ made available by a HTTP server and inside it, run
 \begin{shell}
 path-to-htdocs$\text{\$}$ dpkg-scanpackages path/to/deb-directory /dev/null | gzip -9c > path/to/deb-directory/Packages.gz
 \end{shell}
-This will create a respository index file named \code{Packages.gz}.
+This will create a repository index file named \code{Packages.gz}.
 Note that you must execute this command in the root directory of the
 HTTP server's web directory and provide the relative path to the
 package files -- otherwise, the index file will specify the wrong package

--- a/doc/development.tex
+++ b/doc/development.tex
@@ -113,4 +113,4 @@ used via the generic interface they implement. You will find that almost all plu
 (e.g. emitters) don't actually provide a header file, hence they can only be accessed
 using the generic \code{Emitter} interface they implement. If any kind of special
 interaction between plugins is needed, this is usually an indication that the
-generic interface should be extended to accomodate this.
+generic interface should be extended to accommodate this.

--- a/doc/format.tex
+++ b/doc/format.tex
@@ -158,7 +158,7 @@ enforced via the \texttt{intent} XML attribute, e.g.:
 <rgb name="spectrumProperty" intent="reflectance" value="0.2, 0.8, 0.4"/>
 <rgb name="spectrumProperty" intent="illuminant" value="0.2, 0.8, 0.4"/>
 \end{xml}
-Usually this attribute is not neccessary:
+Usually this attribute is not necessary:
 Mitsuba detects when an RGB value is specified in the declaration of a light source
 and uses \texttt{intent="illuminant"} in this case and \texttt{intent="reflectance"}
 everywhere else.
@@ -310,7 +310,7 @@ The \code{up} parameter is not needed for spot lights.
 <lookat origin="10, 50, -800" target="0, 0, 0" up="0, 1, 0"/>
 \end{xml}
 \end{itemize}
-Cordinates that are zero (for \code{translate} and \code{rotate}) or one (for \code{scale})
+Coordinates that are zero (for \code{translate} and \code{rotate}) or one (for \code{scale})
 do not explicitly have to be specified.
 \newpage
 \subsection{Animated transformations}

--- a/doc/introduction.tex
+++ b/doc/introduction.tex
@@ -39,7 +39,7 @@ One focus of Mitsuba will be to develop path-space light transport algorithms, w
 cases more gracefully.
 
 \parheader{Scalability:} Mitsuba instances can be merged into large clusters, which transparently distribute and
-jointly execute tasks assigned to them using only node-to-node communcation. It has successfully
+jointly execute tasks assigned to them using only node-to-node communication. It has successfully
 scaled to large-scale renderings that involved more than 1000 cores working on a single image.
 Most algorithms in Mitsuba  are written using a generic parallelization layer, which can tap
 into this cluster-wide parallelism. The principle is that if any component of the renderer produces

--- a/doc/parallelization.tex
+++ b/doc/parallelization.tex
@@ -71,7 +71,7 @@ Hello world!
 \end{shell}
 
 Our approach for implementing distributed ROT13 will be to treat each character as an
-indpendent work unit. Since the ordering is lost when sending out work units, we must
+independent work unit. Since the ordering is lost when sending out work units, we must
 also include the position of the character in both the work units and the work results.
 
 All of the relevant interfaces are contained in \code{include/mitsuba/core/sched.h}.

--- a/doc/python.tex
+++ b/doc/python.tex
@@ -128,7 +128,7 @@ from mitsuba.render import SceneHandler
 # Get a reference to the thread's file resolver
 fileResolver = Thread.getThread().getFileResolver()
 
-# Register any searchs path needed to load scene resources (optional)
+# Register any search paths needed to load scene resources (optional)
 fileResolver.appendPath('<path to scene directory>')
 
 # Optional: supply parameters that can be accessed
@@ -514,7 +514,7 @@ conveniently accomplished via the Python interface. In a turntable
 video, the camera rotates around a completely static object or scene.
 The following snippet does this for the material test ball scene downloadable
 on the main website, complete with motion blur. It assumes that the
-scene and scheduler have been set up approriately using one of the previous
+scene and scheduler have been set up appropriately using one of the previous
 snippets.
 \begin{python}
 sensor = scene.getSensor()

--- a/doc/section_media.tex
+++ b/doc/section_media.tex
@@ -19,7 +19,7 @@ fog, smoke, and clouds, over translucent materials such as skin or milk,
 to ``fuzzy'' structured substances such as woven or knitted cloth.
 
 This section describes the two available types of media
-(\pluginref{homogeneous} and \pluginref{heterogeneous}). In pratice, these
+(\pluginref{homogeneous} and \pluginref{heterogeneous}). In practice, these
 will be combined with a phase function, which are described in \secref{phase}.
 Participating media are usually also attached to shapes in the scene.
 How this is done is described at the beginning of \secref{shapes} on page

--- a/doc/section_rfilters.tex
+++ b/doc/section_rfilters.tex
@@ -8,10 +8,10 @@ This section gives a brief overview of the reconstruction filters that are avail
 There is no universally superior filter, and the final choice depends on a trade-off between
 sharpness, ringing, and aliasing, and computational efficiency.
 
-Desireable properties of a reconstruction filter are that it sharply captures all of the details that
+Desirable properties of a reconstruction filter are that it sharply captures all of the details that
 are displayable at the requested image resolution, while avoiding aliasing and ringing. Aliasing is
 the incorrect leakage of high-frequency into low-frequency detail, and ringing denotes oscillation artifacts
-near discontinuities, such as a light-shadow transiton.
+near discontinuities, such as a light-shadow transition.
 
 \begin{description}
 \item[Box filter (\code{box}):]


### PR DESCRIPTION
Found via `codespell -q 3 -L contributer,te`