### PR TITLE
Alpha channel support for BDPT

### DIFF
--- a/src/integrators/bdpt/bdpt_proc.cpp
+++ b/src/integrators/bdpt/bdpt_proc.cpp
@@ -310,7 +310,8 @@ public:
                     wr->putLightSample(samplePos, value * miWeight);
             }
         }
-        wr->putSample(initialSamplePos, sampleValue);
+        if (sensorSubpath.vertexCount() > 2)
+            wr->putSample(initialSamplePos, sampleValue);
     }
 
     ref<WorkProcessor> clone() const {


### PR DESCRIPTION
With the alpha channel enabled, even if there is no contribution for a pixel, BDPT still has the pixel as black with alpha 1.0.