### PR TITLE
Alpha channel support for BDPT

### DIFF
--- a/src/integrators/bdpt/bdpt_proc.cpp
+++ b/src/integrators/bdpt/bdpt_proc.cpp
@@ -310,7 +310,7 @@ public:
                     wr->putLightSample(samplePos, value * miWeight);
             }
         }
-        wr->putSample(initialSamplePos, sampleValue);
+        wr->putSample(initialSamplePos, sampleValue, sensorSubpath.vertexCount() > 2 ? 1.0f : 0.0f);
     }
 
     ref<WorkProcessor> clone() const {

--- a/src/integrators/bdpt/bdpt_wr.h
+++ b/src/integrators/bdpt/bdpt_wr.h
@@ -63,8 +63,8 @@ public:
     }
 #endif
 
-    inline void putSample(const Point2 &sample, const Spectrum &spec) {
-        m_block->put(sample, spec, 1.0f);
+    inline void putSample(const Point2 &sample, const Spectrum &spec, Float alpha) {
+        m_block->put(sample, spec, alpha);
     }
 
     inline void putLightSample(const Point2 &sample, const Spectrum &spec) {


### PR DESCRIPTION
With the alpha channel enabled for film, even if there is no contribution for a pixel, BDPT still has the pixel as black with alpha **1.0**.